### PR TITLE
Disconnect NanScope and NanReturnValue

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,8 +161,6 @@ using v8::Number;
 
 // Simple synchronous access to the `Estimate()` function
 NAN_METHOD(CalculateSync) {
-  NanScope();
-
   // expect a number as the first argument
   int points = args[0]->Uint32Value();
   double est = Estimate(points);
@@ -228,8 +226,6 @@ class PiWorker : public NanAsyncWorker {
 
 // Asynchronous access to the `Estimate()` function
 NAN_METHOD(CalculateAsync) {
-  NanScope();
-
   int points = args[0]->Uint32Value();
   NanCallback *callback = new NanCallback(args[1].As<Function>());
 
@@ -440,7 +436,6 @@ NAN_GC_CALLBACK(gcPrologueCallback) {
 }
 
 NAN_METHOD(Hook) {
-  NanScope();
   NanAssignPersistent(callback, args[0].As<Function>());
   NanAddGCPrologueCallback(gcPrologueCallback);
   NanReturnValue(args.Holder());
@@ -605,12 +600,10 @@ NAN_METHOD(Foo::Baz) {
 <a name="api_nan_scope"></a>
 ### NanScope()
 
-The introduction of `isolate` references for many V8 calls in Node 0.11 makes `NanScope()` necessary, use it in place of `HandleScope scope` when you do not wish to return handles (`Handle` or `Local`) to the surrounding scope (or in functions directly exposed to V8, as they do not return values in the normal sense):
+The introduction of `isolate` references for many V8 calls in Node 0.11 makes `NanScope()` necessary, use it in place of `HandleScope scope` when you do not wish to return handles (`Handle` or `Local`) to the surrounding scope (or in functions directly exposed to V8, as they do not return values in the normal sense). V8-exposed methods (NAN_METHOD, etc.) have implicit handle scopes and do not need extra scopes:
 
 ```c++
 NAN_METHOD(Foo::Bar) {
-  NanScope();
-
   NanReturnValue(NanNew<String>("FooBar!"));
 }
 ```
@@ -783,7 +776,6 @@ Convert a `String` to zero-terminated, sort-of Ascii-encoded `char *`. The under
 
 ```c++
 NAN_METHOD(foo) {
-  NanScope();
   NanReturnValue(NanNew(*NanAsciiString(arg[0])));
 }
 ```
@@ -794,7 +786,6 @@ the buffer `str` points to has been freed when `baz` was destroyed:
 static char *str;
 
 NAN_METHOD(bar) {
-  NanScope();
   NanAsciiString baz(arg[0]);
 
   str = *baz;
@@ -811,7 +802,6 @@ printf(str); // use-after-free error
 static NanAsciiString *str;
 
 NAN_METHOD(bar) {
-  NanScope();
   str = new NanAsciiString(arg[0]);
   NanReturnUndefined();
 }
@@ -829,7 +819,6 @@ Convert a `String` to zero-terminated, Utf8-encoded `char *`. The underlying buf
 
 ```c++
 NAN_METHOD(foo) {
-  NanScope();
   NanReturnValue(NanNew(*NanUtf8String(arg[0])));
 }
 ```
@@ -840,7 +829,6 @@ the buffer `str` points to has been freed when `baz` was destroyed:
 static char *str;
 
 NAN_METHOD(bar) {
-  NanScope();
   NanUtf8String baz(arg[0]);
 
   str = *baz;
@@ -857,7 +845,6 @@ printf(str); // use-after-free error
 static NanUtf8String *str;
 
 NAN_METHOD(bar) {
-  NanScope();
   str = new NanUtf8String(arg[0]);
   NanReturnUndefined();
 }
@@ -876,7 +863,6 @@ Convert a `String` to zero-terminated, Ucs2-encoded `uint16_t *`. The underlying
 
 ```c++
 NAN_METHOD(foo) {
-  NanScope();
   NanReturnValue(NanNew(*NanUcs2String(arg[0])));
 }
 ```
@@ -887,7 +873,6 @@ the buffer `str` points to has been freed when `baz` was destroyed:
 static char *str;
 
 NAN_METHOD(bar) {
-  NanScope();
   NanUcs2String baz(arg[0]);
 
   str = *baz;
@@ -904,7 +889,6 @@ printf(str); // use-after-free error
 static NanUcs2String *str;
 
 NAN_METHOD(bar) {
-  NanScope();
   str = new NanUcs2String(arg[0]);
   NanReturnUndefined();
 }

--- a/examples/async_pi_estimate/async.cc
+++ b/examples/async_pi_estimate/async.cc
@@ -51,8 +51,6 @@ class PiWorker : public NanAsyncWorker {
 
 // Asynchronous access to the `Estimate()` function
 NAN_METHOD(CalculateAsync) {
-  NanScope();
-
   int points = args[0]->Uint32Value();
   NanCallback *callback = new NanCallback(args[1].As<Function>());
 

--- a/examples/async_pi_estimate/sync.cc
+++ b/examples/async_pi_estimate/sync.cc
@@ -14,8 +14,6 @@ using v8::Number;
 
 // Simple synchronous access to the `Estimate()` function
 NAN_METHOD(CalculateSync) {
-  NanScope();
-
   // expect a number as the first argument
   int points = args[0]->Uint32Value();
   double est = Estimate(points);

--- a/nan.h
+++ b/nan.h
@@ -832,7 +832,7 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
 # define NanEscapeScope(val) scope.Close(val)
 # define NanLocker() v8::Locker locker
 # define NanUnlocker() v8::Unlocker unlocker
-# define NanReturnValue(value) return scope.Close(value)
+# define NanReturnValue(value) return value
 # define NanReturnHolder() NanReturnValue(args.Holder())
 # define NanReturnThis() NanReturnValue(args.This())
 # define NanReturnUndefined() return v8::Undefined()

--- a/test/cpp/asyncprogressworker.cpp
+++ b/test/cpp/asyncprogressworker.cpp
@@ -46,7 +46,6 @@ class ProgressWorker : public NanAsyncProgressWorker {
 };
 
 NAN_METHOD(DoProgress) {
-  NanScope();
   NanCallback *progress = new NanCallback(args[2].As<v8::Function>());
   NanCallback *callback = new NanCallback(args[3].As<v8::Function>());
   NanAsyncQueueWorker(new ProgressWorker(

--- a/test/cpp/asyncworker.cpp
+++ b/test/cpp/asyncworker.cpp
@@ -27,7 +27,6 @@ class SleepWorker : public NanAsyncWorker {
 };
 
 NAN_METHOD(DoSleep) {
-  NanScope();
   NanCallback *callback = new NanCallback(args[1].As<v8::Function>());
   NanAsyncQueueWorker(new SleepWorker(callback, args[0]->Uint32Value()));
   NanReturnUndefined();

--- a/test/cpp/asyncworkererror.cpp
+++ b/test/cpp/asyncworkererror.cpp
@@ -19,7 +19,6 @@ class ErrorWorker : public NanAsyncWorker {
 };
 
 NAN_METHOD(Work) {
-  NanScope();
   NanCallback *callback = new NanCallback(args[0].As<v8::Function>());
   NanAsyncQueueWorker(new ErrorWorker(callback));
   NanReturnUndefined();

--- a/test/cpp/bufferworkerpersistent.cpp
+++ b/test/cpp/bufferworkerpersistent.cpp
@@ -45,7 +45,6 @@ class BufferWorker : public NanAsyncWorker {
 };
 
 NAN_METHOD(DoSleep) {
-  NanScope();
   v8::Local<v8::Object> bufferHandle = args[1].As<v8::Object>();
   NanCallback *callback = new NanCallback(args[2].As<v8::Function>());
   assert(!callback->IsEmpty() && "Callback shoud not be empty");

--- a/test/cpp/gc.cpp
+++ b/test/cpp/gc.cpp
@@ -21,7 +21,6 @@ NAN_GC_CALLBACK(gcEpilogueCallback) {
 }
 
 NAN_METHOD(Hook) {
-  NanScope();
   NanAssignPersistent(callback, args[0].As<v8::Function>());
   NanAddGCPrologueCallback(gcPrologueCallback);
   NanAddGCEpilogueCallback(gcEpilogueCallback);

--- a/test/cpp/isolatedata.cpp
+++ b/test/cpp/isolatedata.cpp
@@ -13,8 +13,6 @@ struct Dummy {
 };
 
 NAN_METHOD(SetAndGet) {
-  NanScope();
-
   Dummy *d0 = new Dummy;
   Dummy *d1 = NULL;
 

--- a/test/cpp/makecallback.cpp
+++ b/test/cpp/makecallback.cpp
@@ -44,8 +44,6 @@ void MyObject::Init(v8::Handle<v8::Object> exports) {
 }
 
 NAN_METHOD(MyObject::New) {
-    NanScope();
-
     if (args.IsConstructCall()) {
         MyObject* obj = new MyObject();
         obj->Wrap(args.This());
@@ -58,7 +56,6 @@ NAN_METHOD(MyObject::New) {
 }
 
 NAN_METHOD(MyObject::CallEmit) {
-    NanScope();
     v8::Handle<v8::Value> argv[1] = {
         NanNew("event"), // event name
     };

--- a/test/cpp/morenews.cpp
+++ b/test/cpp/morenews.cpp
@@ -9,34 +9,28 @@
 #include <nan.h>
 
 NAN_METHOD(NewNumber) {
-  NanScope();
   NanReturnValue(NanNew(0.5));
 }
 
 NAN_METHOD(NewNegativeInteger) {
-  NanScope();
   NanReturnValue(NanNew(-1));
 }
 
 NAN_METHOD(NewPositiveInteger) {
-  NanScope();
   NanReturnValue(NanNew(1));
 }
 
 NAN_METHOD(NewUtf8String) {
-  NanScope();
   const char s[] = "strïng";
   NanReturnValue(NanNew(s));
 }
 
 NAN_METHOD(NewLatin1String) {
-  NanScope();
   const uint8_t s[] = "str\xefng";
   NanReturnValue(NanNew(s));
 }
 
 NAN_METHOD(NewUcs2String) {
-  NanScope();
   uint16_t s[] = {'s', 't', 'r', 0xef, 'n', 'g', '\0'};
   NanReturnValue(NanNew(s));
 }
@@ -64,13 +58,11 @@ class ExtAsciiString : public v8::String::ExternalAsciiStringResource {
 };
 
 NAN_METHOD(NewExternalStringResource) {
-  NanScope();
   v8::Local<v8::String> ext = NanNew(new ExtString());
   NanReturnValue(ext);
 }
 
 NAN_METHOD(NewExternalAsciiStringResource) {
-  NanScope();
   v8::Local<v8::String> ext = NanNew(new ExtAsciiString());
   NanReturnValue(ext);
 }

--- a/test/cpp/multifile2.cpp
+++ b/test/cpp/multifile2.cpp
@@ -9,7 +9,6 @@
 #include <nan.h>
 
 NAN_METHOD(ReturnString) {
-  NanScope();
   v8::Local<v8::String> s = NanNew<v8::String>(*NanUtf8String(args[0]));
   NanReturnValue(s);
 }

--- a/test/cpp/nancallback.cpp
+++ b/test/cpp/nancallback.cpp
@@ -8,17 +8,12 @@
 
 #include <nan.h>
 
-
 NAN_METHOD(GlobalContext) {
-  NanScope();
-
   NanCallback(args[0].As<v8::Function>()).Call(0, NULL);
   NanReturnUndefined();
 }
 
 NAN_METHOD(SpecificContext) {
-  NanScope();
-
   NanCallback cb(args[0].As<v8::Function>());
   cb.Call(NanGetCurrentContext()->Global(), 0, NULL);
   NanReturnUndefined();

--- a/test/cpp/nannew.cpp
+++ b/test/cpp/nannew.cpp
@@ -51,7 +51,6 @@ stringMatches(Local<Value> value, const char * match) {
 #define _(e) NAN_TEST_EXPRESSION(e)
 
 NAN_METHOD(testArray) {
-  NanScope();
   NanTap t(args[0]);
 
   t.plan(3);
@@ -64,7 +63,6 @@ NAN_METHOD(testArray) {
 }
 
 NAN_METHOD(testBoolean) {
-  NanScope();
   NanTap t(args[0]);
 
   t.plan(6);
@@ -86,7 +84,6 @@ NAN_METHOD(testBoolean) {
 # define V(x) x->ValueOf()
 #endif
 NAN_METHOD(testBooleanObject) {
-  NanScope();
   NanTap t(args[0]);
 
   t.plan(3);
@@ -100,7 +97,6 @@ NAN_METHOD(testBooleanObject) {
 #undef V
 
 NAN_METHOD(testContext) {
-  NanScope();
   NanTap t(args[0]);
 
   t.plan(4);
@@ -117,7 +113,6 @@ NAN_METHOD(testContext) {
 }
 
 NAN_METHOD(testDate) {
-  NanScope();
   NanTap t(args[0]);
 
   t.plan(1);
@@ -130,7 +125,6 @@ NAN_METHOD(testDate) {
 int ttt = 23;
 
 NAN_METHOD(testExternal) {
-  NanScope();
   NanTap t(args[0]);
 
   t.plan(2);
@@ -142,7 +136,6 @@ NAN_METHOD(testExternal) {
 }
 
 NAN_METHOD(testFunction) {
-  NanScope();
   NanTap t(args[0]);
   t.plan(2);
 
@@ -154,7 +147,6 @@ NAN_METHOD(testFunction) {
 }
 
 NAN_METHOD(testFunctionTemplate) {
-  NanScope();
   NanTap t(args[0]);
 
   t.plan(4);
@@ -175,7 +167,6 @@ NAN_METHOD(testFunctionTemplate) {
 const double epsilon = 1e-9;
 
 NAN_METHOD(testNumber) {
-  NanScope();
   NanTap t(args[0]);
 
   t.plan(17);
@@ -210,7 +201,6 @@ NAN_METHOD(testNumber) {
 }
 
 NAN_METHOD(testNumberObject) {
-  NanScope();
   NanTap t(args[0]);
 
   t.plan(2);
@@ -222,7 +212,6 @@ NAN_METHOD(testNumberObject) {
 }
 
 NAN_METHOD(testObject) {
-  NanScope();
   NanTap t(args[0]);
 
   t.plan(1);
@@ -244,7 +233,6 @@ NAN_METHOD(testObjectTemplate) {
 }
 
 NAN_METHOD(testScript) {
-  NanScope();
   NanTap t(args[0]);
 
   t.plan(6);
@@ -268,7 +256,6 @@ NAN_METHOD(testScript) {
 }
 
 NAN_METHOD(testSignature) {
-  NanScope();
   NanTap t(args[0]);
 
   t.plan(3);
@@ -286,7 +273,6 @@ NAN_METHOD(testSignature) {
 }
 
 NAN_METHOD(testString) {
-  NanScope();
   NanTap t(args[0]);
 
   t.plan(14);
@@ -325,7 +311,6 @@ NAN_METHOD(testString) {
 # define V(x) x->ValueOf()
 #endif
 NAN_METHOD(testStringObject) {
-  NanScope();
   NanTap t(args[0]);
 
   t.plan(2);
@@ -342,7 +327,6 @@ NAN_METHOD(testStringObject) {
 
 template <typename T> Handle<T> asHandle(Local<T> l) { return l; }
 NAN_METHOD(testHandles) {
-  NanScope();
   NanTap t(args[0]);
 
   t.plan(2);
@@ -354,7 +338,6 @@ NAN_METHOD(testHandles) {
 }
 
 NAN_METHOD(testPersistents) {
-  NanScope();
   NanTap t(args[0]);
 
   t.plan(1);
@@ -374,7 +357,6 @@ NAN_METHOD(testPersistents) {
 
 // See https://github.com/rvagg/nan/issues/212
 NAN_METHOD(testRegression212) {
-  NanScope();
   NanTap t(args[0]);
 
   t.plan(1);
@@ -403,7 +385,6 @@ NAN_METHOD(overloaded) {
 }
 
 NAN_METHOD(testRegression242) {
-  NanScope();
   NanTap t(args[0]);
 
   // These lines must *compile*. Not much to test at runtime.
@@ -425,37 +406,30 @@ NAN_METHOD(testRegression242) {
 //==============================================================================
 
 NAN_METHOD(newIntegerWithValue) {
-  NanScope();
   return_NanValue(NanNew<Integer>(args[0]->Int32Value()));
 }
 
 NAN_METHOD(newNumberWithValue) {
-  NanScope();
   return_NanValue(NanNew<Number>(args[0]->NumberValue()));
 }
 
 NAN_METHOD(newUint32WithValue) {
-  NanScope();
   return_NanValue(NanNew<Uint32>(args[0]->Uint32Value()));
 }
 
 NAN_METHOD(newStringFromChars) {
-  NanScope();
   return_NanValue(NanNew<String>("hello?"));
 }
 
 NAN_METHOD(newStringFromCharsWithLength) {
-  NanScope();
   return_NanValue(NanNew<String>("hello?", 4));
 }
 
 NAN_METHOD(newStringFromStdString) {
-  NanScope();
   return_NanValue(NanNew<String>(std::string("hello!")));
 }
 
 NAN_METHOD(newExternal) {
-  NanScope();
   return_NanValue(NanNew<External>(&ttt));
 }
 

--- a/test/cpp/news.cpp
+++ b/test/cpp/news.cpp
@@ -18,98 +18,80 @@
 static int magic = 1337;
 
 NAN_METHOD(NewNumber) {
-  NanScope();
   NanReturnValue(NanNew<v8::Number>(0.5));
 }
 
 NAN_METHOD(NewNegativeInteger) {
-  NanScope();
   NanReturnValue(NanNew<v8::Integer>(-1));
 }
 
 NAN_METHOD(NewPositiveInteger) {
-  NanScope();
   NanReturnValue(NanNew<v8::Integer>(1));
 }
 
 NAN_METHOD(NewUnsignedInteger) {
-  NanScope();
   NanReturnValue(NanNew<v8::Integer>(0xFFFFFFFFu));
 }
 
 NAN_METHOD(NewInt32FromPositive) {
-  NanScope();
   NanReturnValue(NanNew<v8::Int32>(0xFFFFFFFF));
 }
 
 NAN_METHOD(NewInt32FromNegative) {
-  NanScope();
   NanReturnValue(NanNew<v8::Int32>(-1));
 }
 
 NAN_METHOD(NewUint32FromPositive) {
-  NanScope();
   NanReturnValue(NanNew<v8::Uint32>(0xFFFFFFFF));
 }
 
 NAN_METHOD(NewUint32FromNegative) {
-  NanScope();
   NanReturnValue(NanNew<v8::Uint32>(-1));
 }
 
 NAN_METHOD(NewUtf8String) {
-  NanScope();
   const char s[] = "strïng";
   NanReturnValue(NanNew<v8::String>(s));
 }
 
 NAN_METHOD(NewLatin1String) {
-  NanScope();
   const uint8_t s[] = "str\xefng";
   NanReturnValue(NanNew<v8::String>(s));
 }
 
 NAN_METHOD(NewUcs2String) {
-  NanScope();
   const uint16_t s[] = {'s', 't', 'r', 0xef, 'n', 'g', '\0'};
   NanReturnValue(NanNew(s));
 }
 
 NAN_METHOD(NewStdString) {
-  NanScope();
   const std::string s = "strïng";
   NanReturnValue(NanNew<v8::String>(s));
 }
 
 NAN_METHOD(NewRegExp) {
-  NanScope();
   NanReturnValue(NanNew<v8::RegExp>(NanNew("foo"), v8::RegExp::kNone));
 }
 
 NAN_METHOD(NewStringObject) {
-  NanScope();
   NanReturnValue(NanNew<v8::StringObject>(NanNew<v8::String>("foo")));
 }
 
 NAN_METHOD(NewNumberObject) {
-  NanScope();
   NanReturnValue(NanNew<v8::NumberObject>(0.5));
 }
 
 NAN_METHOD(NewBooleanObject) {
-  NanScope();
   NanReturnValue(NanNew<v8::BooleanObject>(true));
 }
 
 NAN_METHOD(NewExternal) {
-  NanScope();
   v8::Local<v8::External> ext = NanNew<v8::External>(&magic);
   assert(*static_cast<int *>(ext->Value()) == 1337);
   NanReturnValue(NanNew<v8::String>("passed"));
 }
 
 NAN_METHOD(NewSignature) {
-  NanScope();
   v8::Local<v8::FunctionTemplate> tmpl =
       NanNew<v8::FunctionTemplate>(NewSignature);
   v8::Local<v8::Signature> sig = NanNew<v8::Signature>(tmpl, 1, &tmpl);
@@ -119,13 +101,11 @@ NAN_METHOD(NewSignature) {
 }
 
 NAN_METHOD(NewScript) {
-  NanScope();
   v8::Local<NanUnboundScript> script = NanNew<NanUnboundScript>(NanNew("2+4"));
   NanReturnValue(NanRunScript(script)->ToInt32());
 }
 
 NAN_METHOD(NewScript2) {
-  NanScope();
   v8::ScriptOrigin origin(NanNew<v8::String>("x"));
   v8::Local<NanUnboundScript> script =
       NanNew<NanUnboundScript>(NanNew("2+4"), origin);
@@ -133,36 +113,30 @@ NAN_METHOD(NewScript2) {
 }
 
 NAN_METHOD(CompileScript) {
-  NanScope();
   v8::Local<NanBoundScript> script = NanCompileScript(NanNew("2+4"));
   NanReturnValue(NanRunScript(script)->ToInt32());
 }
 
 NAN_METHOD(CompileScript2) {
-  NanScope();
   v8::ScriptOrigin origin(NanNew<v8::String>("x"));
   v8::Local<NanBoundScript> script = NanCompileScript(NanNew("2+4"), origin);
   NanReturnValue(NanRunScript(script)->ToInt32());
 }
 
 NAN_METHOD(NewDate) {
-  NanScope();
   NanReturnValue(NanNew<v8::Date>(1337));
 }
 
 NAN_METHOD(NewArray) {
-  NanScope();
   NanReturnValue(NanNew<v8::Array>());
 }
 
 NAN_METHOD(NewBoolean) {
-  NanScope();
   NanReturnValue(NanNew<v8::Boolean>(true));
 }
 
 // #212
 NAN_METHOD(NewBoolean2) {
-  NanScope();
   #if defined(_MSC_VER)
   # pragma warning( disable : 4800 )
   #endif

--- a/test/cpp/optionvalues.cpp
+++ b/test/cpp/optionvalues.cpp
@@ -9,8 +9,6 @@
 #include <nan.h>
 
 NAN_METHOD(OptionValues) {
-  NanScope();
-
   v8::Local<v8::Object> inobj = args[0].As<v8::Object>();
   v8::Local<v8::Object> outobj = NanNew<v8::Object>();
 

--- a/test/cpp/persistent.cpp
+++ b/test/cpp/persistent.cpp
@@ -12,48 +12,34 @@
 static v8::Persistent<v8::String> persistentTest1;
 
 NAN_METHOD(Save1) {
-  NanScope();
-
   NanAssignPersistent(persistentTest1, args[0].As<v8::String>());
-
   NanReturnUndefined();
 }
 
 NAN_METHOD(Get1) {
-  NanScope();
-
   NanReturnValue(NanNew(persistentTest1));
 }
 
 NAN_METHOD(Dispose1) {
-  NanScope();
-
   NanDisposePersistent(persistentTest1);
-
   NanReturnUndefined();
 }
 
 NAN_METHOD(ToPersistentAndBackAgain) {
-  NanScope();
-
   v8::Persistent<v8::Object> persistent;
   NanAssignPersistent(persistent, args[0].As<v8::Object>());
   v8::Local<v8::Object> object = NanNew(persistent);
   NanDisposePersistent(persistent);
   memset(&persistent, -1, sizeof(persistent));  // Clobber it good.
-
   NanReturnValue(object);
 }
 
 NAN_METHOD(PersistentToPersistent) {
-  NanScope();
-
   v8::Persistent<v8::String> persistent;
   NanAssignPersistent(persistent, args[0].As<v8::String>());
   NanAssignPersistent(persistentTest1, persistent);
   NanDisposePersistent(persistent);
   NanDisposePersistent(persistentTest1);
-
   NanReturnUndefined();
 }
 

--- a/test/cpp/returnemptystring.cpp
+++ b/test/cpp/returnemptystring.cpp
@@ -9,7 +9,6 @@
 #include <nan.h>
 
 NAN_METHOD(ReturnEmptyString) {
-  NanScope();
   NanReturnEmptyString();
 }
 

--- a/test/cpp/returnnull.cpp
+++ b/test/cpp/returnnull.cpp
@@ -9,7 +9,6 @@
 #include <nan.h>
 
 NAN_METHOD(ReturnNull) {
-  NanScope();
   NanReturnNull();
 }
 

--- a/test/cpp/returnundefined.cpp
+++ b/test/cpp/returnundefined.cpp
@@ -9,7 +9,6 @@
 #include <nan.h>
 
 NAN_METHOD(ReturnUndefined) {
-  NanScope();
   NanReturnUndefined();
 }
 

--- a/test/cpp/returnvalue.cpp
+++ b/test/cpp/returnvalue.cpp
@@ -9,7 +9,6 @@
 #include <nan.h>
 
 NAN_METHOD(ReturnValue) {
-  NanScope();
   if (args.Length() == 1) {
     NanReturnValue(args[0]);
   } else {

--- a/test/cpp/settemplate.cpp
+++ b/test/cpp/settemplate.cpp
@@ -51,8 +51,6 @@ void MyObject::Init(v8::Handle<v8::Object> exports) {
 }
 
 NAN_METHOD(MyObject::New) {
-	NanScope();
-
 	if (args.IsConstructCall()) {
 		MyObject* obj = new MyObject();
 		obj->Wrap(args.This());

--- a/test/cpp/settergetter.cpp
+++ b/test/cpp/settergetter.cpp
@@ -29,7 +29,6 @@ class SetterGetter : public node::ObjectWrap {
 static v8::Persistent<v8::FunctionTemplate> settergetter_constructor;
 
 NAN_METHOD(CreateNew) {
-  NanScope();
   NanReturnValue(SetterGetter::NewInstance());
 }
 
@@ -41,6 +40,7 @@ SetterGetter::SetterGetter() {
 }
 
 void SetterGetter::Init(v8::Handle<v8::Object> target) {
+  NanScope();
   v8::Local<v8::FunctionTemplate> tpl =
     NanNew<v8::FunctionTemplate>(SetterGetter::New);
   NanAssignPersistent(settergetter_constructor, tpl);
@@ -61,16 +61,15 @@ void SetterGetter::Init(v8::Handle<v8::Object> target) {
 }
 
 v8::Handle<v8::Value> SetterGetter::NewInstance () {
+  NanEscapableScope();
   v8::Local<v8::FunctionTemplate> constructorHandle =
       NanNew(settergetter_constructor);
   v8::Local<v8::Object> instance =
     constructorHandle->GetFunction()->NewInstance(0, NULL);
-  return instance;
+  return NanEscapeScope(instance);
 }
 
 NAN_METHOD(SetterGetter::New) {
-  NanScope();
-
   SetterGetter* settergetter = new SetterGetter();
   assert(strlen(settergetter->log) < sizeof (settergetter->log));
   strncat(
@@ -83,8 +82,6 @@ NAN_METHOD(SetterGetter::New) {
 }
 
 NAN_GETTER(SetterGetter::GetProp1) {
-  NanScope();
-
   SetterGetter* settergetter =
     node::ObjectWrap::Unwrap<SetterGetter>(args.This());
   assert(strlen(settergetter->log) < sizeof (settergetter->log));
@@ -107,8 +104,6 @@ NAN_GETTER(SetterGetter::GetProp1) {
 }
 
 NAN_GETTER(SetterGetter::GetProp2) {
-  NanScope();
-
   SetterGetter* settergetter =
     node::ObjectWrap::Unwrap<SetterGetter>(args.This());
   assert(strlen(settergetter->log) < sizeof (settergetter->log));
@@ -131,8 +126,6 @@ NAN_GETTER(SetterGetter::GetProp2) {
 }
 
 NAN_SETTER(SetterGetter::SetProp2) {
-  NanScope();
-
   SetterGetter* settergetter =
       node::ObjectWrap::Unwrap<SetterGetter>(args.This());
   strncpy(
@@ -158,8 +151,6 @@ NAN_SETTER(SetterGetter::SetProp2) {
 }
 
 NAN_METHOD(SetterGetter::Log) {
-  NanScope();
-
   SetterGetter* settergetter =
     node::ObjectWrap::Unwrap<SetterGetter>(args.This());
 

--- a/test/cpp/strings.cpp
+++ b/test/cpp/strings.cpp
@@ -9,22 +9,18 @@
 #include <nan.h>
 
 NAN_METHOD(ReturnAsciiString) {
-  NanScope();
   NanReturnValue(NanNew(*NanAsciiString(args[0])));
 }
 
 NAN_METHOD(ReturnUtf8String) {
-  NanScope();
   NanReturnValue(NanNew(*NanUtf8String(args[0])));
 }
 
 NAN_METHOD(ReturnUcs2String) {
-  NanScope();
   NanReturnValue(NanNew(*NanUcs2String(args[0])));
 }
 
 NAN_METHOD(HeapString) {
-  NanScope();
   NanUcs2String *s = new NanUcs2String(args[0]);
   v8::Local<v8::String> res = NanNew(**s);
   delete s;
@@ -32,12 +28,10 @@ NAN_METHOD(HeapString) {
 }
 
 NAN_METHOD(EncodeHex) {
-  NanScope();
   NanReturnValue(NanEncode("hello", 5, Nan::HEX));
 }
 
 NAN_METHOD(EncodeUCS2) {
-  NanScope();
   NanReturnValue(NanEncode("h\0e\0l\0l\0o\0", 10, Nan::UCS2));
 }
 
@@ -49,8 +43,6 @@ v8::Persistent<v8::FunctionTemplate> encodeHex_persistent;
 v8::Persistent<v8::FunctionTemplate> encodeUCS2_persistent;
 
 void Init (v8::Handle<v8::Object> target) {
-  NanScope();
-
   v8::Local<v8::FunctionTemplate> returnAsciiString =
     NanNew<v8::FunctionTemplate>(ReturnAsciiString);
 

--- a/test/cpp/weak.cpp
+++ b/test/cpp/weak.cpp
@@ -19,14 +19,14 @@ NAN_WEAK_CALLBACK(weakCallback) {
 }
 
 v8::Handle<v8::String> wrap(v8::Local<v8::Function> func) {
+  NanEscapableScope();
   v8::Local<v8::String> lstring = NanNew<v8::String>("result");
   int *parameter = new int(0);
   NanMakeWeakPersistent(func, parameter, &weakCallback);
-  return lstring;
+  return NanEscapeScope(lstring);
 }
 
 NAN_METHOD(Hustle) {
-  NanScope();
   NanReturnValue(wrap(args[0].As<v8::Function>()));
 }
 


### PR DESCRIPTION
Got rid of a bunch of `NanScope`s, this could improve performance. To get old behavior, use `NanEscapableScope` and combine `NanEscapeScope` with `NanReturnValue`, but this should not be necessary on v8-exposed methods (NAN_METHOD, etc).

I guess this should be held off until NAN 2, as it would break backwards compatibility.