### PR TITLE
feat(SaveToPersistent): Allow saving v8::Value to persistent

### DIFF
--- a/nan.h
+++ b/nan.h
@@ -1511,15 +1511,15 @@ class NanCallback {
   }
 
   NAN_INLINE void SaveToPersistent(
-      const char *key, const v8::Local<v8::Object> &obj) {
+      const char *key, const v8::Local<v8::Value> &value) {
     v8::Local<v8::Object> handle = NanNew(persistentHandle);
-    handle->Set(NanNew<v8::String>(key), obj);
+    handle->Set(NanNew<v8::String>(key), value);
   }
 
-  v8::Local<v8::Object> GetFromPersistent(const char *key) const {
+  v8::Local<v8::Value> GetFromPersistent(const char *key) const {
     NanEscapableScope();
     v8::Local<v8::Object> handle = NanNew(persistentHandle);
-    return NanEscapeScope(handle->Get(NanNew(key)).As<v8::Object>());
+    return NanEscapeScope(handle->Get(NanNew(key)));
   }
 
   virtual void Execute() = 0;

--- a/test/cpp/bufferworkerpersistent.cpp
+++ b/test/cpp/bufferworkerpersistent.cpp
@@ -35,9 +35,8 @@ class BufferWorker : public NanAsyncWorker {
   void HandleOKCallback () {
     NanScope();
 
-    v8::Local<v8::Object> handle = GetFromPersistent("buffer");
-    v8::Local<v8::Value> argv[] = { handle };
-    callback->Call(1, argv);
+    v8::Local<v8::Value> handle = GetFromPersistent("buffer");
+    callback->Call(1, &handle);
   }
 
  private:


### PR DESCRIPTION
NanAsyncWorker previously required saving a v8::Objec to persistent
which did not allow any other value types to be stored. This change
opts for the more generic v8::Value, allowing you to store all
value types in the persistent store.

**NOTE:** I have no idea what kind of requirements you guys have for BC (well okay not BC in this case, but whatever-not-changing-private-api-is-called), this is obviously a breaking change and could be implemented with new accessors/mutators instead. Thoughts?
