### PR TITLE
Backported Maybe types from V8 v4.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,7 +23,10 @@ LINT_SOURCES = \
         test/cpp/asyncprogressworker.cpp \
         test/cpp/asyncworkererror.cpp \
         test/cpp/bufferworkerpersistent.cpp \
+        test/cpp/converters.cpp \
         test/cpp/gc.cpp \
+	test/cpp/isolatedata.cpp \
+	test/cpp/makecallback.cpp \
         test/cpp/morenews.cpp \
 	test/cpp/multifile1.cpp \
 	test/cpp/multifile2.cpp \
@@ -37,9 +40,11 @@ LINT_SOURCES = \
 	test/cpp/returnnull.cpp \
 	test/cpp/returnundefined.cpp \
 	test/cpp/returnvalue.cpp \
+        test/cpp/settemplate.cpp \
 	test/cpp/settergetter.cpp \
 	test/cpp/strings.cpp \
 	test/cpp/symbols.cpp \
+        test/cpp/threadlocal.cpp \
         test/cpp/weak.cpp \
 	node_modules/node-gyp/gyp/data/win/large-pdb-shim.cc
 

--- a/examples/async_pi_estimate/addon.cc
+++ b/examples/async_pi_estimate/addon.cc
@@ -18,10 +18,10 @@ using v8::String;
 // Expose synchronous and asynchronous access to our
 // Estimate() function
 void InitAll(Handle<Object> exports) {
-  exports->Set(NanNew<String>("calculateSync"),
+  exports->Set(NanNew<String>("calculateSync").ToLocalChecked(),
     NanNew<FunctionTemplate>(CalculateSync)->GetFunction());
 
-  exports->Set(NanNew<String>("calculateAsync"),
+  exports->Set(NanNew<String>("calculateAsync").ToLocalChecked(),
     NanNew<FunctionTemplate>(CalculateAsync)->GetFunction());
 }
 

--- a/nan.h
+++ b/nan.h
@@ -1060,6 +1060,10 @@ NAN_INLINE v8::Local<v8::Value> _NanEnsureLocal(T val) {
     return NanEscapeScope(NanNew(v8::False(v8::Isolate::GetCurrent())));
   }
 
+  NAN_INLINE v8::Local<v8::String> NanEmptyString() {
+    return v8::String::Empty(v8::Isolate::GetCurrent());
+  }
+
   NAN_INLINE int NanAdjustExternalMemory(int bc) {
     return static_cast<int>(
         v8::Isolate::GetCurrent()->AdjustAmountOfExternalAllocatedMemory(bc));
@@ -1631,6 +1635,10 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
   NAN_INLINE v8::Local<v8::Boolean> NanFalse() {
     NanEscapableScope();
     return NanEscapeScope(NanNew(v8::False()));
+  }
+
+  NAN_INLINE v8::Local<v8::String> NanEmptyString() {
+    return v8::String::Empty();
   }
 
   NAN_INLINE int NanAdjustExternalMemory(int bc) {

--- a/nan.h
+++ b/nan.h
@@ -77,6 +77,625 @@ typedef v8::String::ExternalOneByteStringResource
     NanExternalOneByteStringResource;
 #endif
 
+#if (NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION)
+typedef void (*NanGetter) (
+    v8::Local<v8::String> property
+  , const v8::PropertyCallbackInfo<v8::Value>& info);
+
+typedef void (*NanSetter) (
+    v8::Local<v8::String> property
+  , v8::Local<v8::Value> value
+  , const v8::PropertyCallbackInfo<void>& info);
+#else
+typedef v8::Handle<v8::Value> (*NanGetter) (
+    v8::Local<v8::String> property
+  , const v8::AccessorInfo& info);
+
+typedef void (*NanSetter) (
+    v8::Local<v8::String> property
+  , v8::Local<v8::Value> value
+  , const v8::AccessorInfo& info);
+#endif  // NODE_MODULE_VERSION
+
+
+#if defined(V8_MAJOR_VERSION) && (V8_MAJOR_VERSION > 4 ||                      \
+  (V8_MAJOR_VERSION == 4 && defined(V8_MINOR_VERSION) && V8_MINOR_VERSION >= 3))
+
+typedef v8::MaybeLocal NanMaybeLocal;
+typedef v8::Maybe NanMaybe;
+
+template<typename T>
+inline NanMaybe<T> NanNothing() {
+  return v8::Nothing<T>();
+}
+
+template<typename T>
+inline NanMaybe<T> NanJust(const T& t) {
+  return v8::Just<T>(t);
+}
+
+NAN_INLINE NanMaybeLocal<v8::Boolean> NanToBoolean(v8::Handle<v8::Value> val) {
+  return val->ToBoolean(NanGetCurrentContext());
+}
+
+NAN_INLINE NanMaybeLocal<v8::Number> NanToNumber(v8::Handle<v8::Value> val) {
+  return val->ToNumber(NanGetCurrentContext());
+}
+
+NAN_INLINE NanMaybeLocal<v8::String> NanToString(v8::Handle<v8::Value> val) {
+  return val->ToString(NanGetCurrentContext());
+}
+
+NAN_INLINE
+NanMaybeLocal<v8::String> NanToDetailString(v8::Handle<v8::Value> val) {
+  return val->ToDetailString(NanGetCurrentContext());
+}
+
+NAN_INLINE NanMaybeLocal<v8::Object> NanToObject(v8::Handle<v8::Value> val) {
+  return val->ToObject(NanGetCurrentContext());
+}
+
+NAN_INLINE NanMaybeLocal<v8::Integer> NanToInteger(v8::Handle<v8::Value> val) {
+  return val->ToInteger(NanGetCurrentContext());
+}
+
+NAN_INLINE NanMaybeLocal<v8::Uint32> NanToUint32(v8::Handle<v8::Value> val) {
+  return val->ToUint32(NanGetCurrentContext());
+}
+
+NAN_INLINE NanMaybeLocal<v8::Int32> NanToInt32(v8::Handle<v8::Value> val) {
+  return val->ToInt32(NanGetCurrentContext());
+}
+
+NAN_INLINE NanMaybe<bool> NanBooleanValue(v8::Handle<v8::Value> val) {
+  return val->BooleanValue(NanGetCurrentContext());
+}
+
+NAN_INLINE NanMaybe<double> NanNumberValue(v8::Handle<v8::Value> val) {
+  return val->NumberValue(NanGetCurrentContext());
+}
+
+NAN_INLINE NanMaybe<int64_t> NanIntegerValue(v8::Handle<v8::Value> val) {
+  return val->IntegerValue(NanGetCurrentContext());
+}
+
+NAN_INLINE NanMaybe<uint32_t> NanUint32Value(v8::Handle<v8::Value> val) {
+  return val->Uint32Value(NanGetCurrentContext());
+}
+
+NAN_INLINE NanMaybe<int32_t> NanInt32Value(v8::Handle<v8::Value> val) {
+  return val->Int32Value(NanGetCurrentContext());
+}
+
+NAN_INLINE
+NanMaybe<bool> NanEquals(v8::Handle<v8::Value> a, v8::Handle<v8::Value>(b)) {
+  return a->Equals(NanGetCurrentContext(), b);
+}
+
+template<typename T>
+NAN_INLINE NanMaybeLocal<T> NanNewInstance(v8::Handle<T> h) {
+  return h->NewInstance(NanGetCurrentContext());
+}
+
+NAN_INLINE NanMaybeLocal<v8::Function> NanGetFunction(
+    v8::Handle<v8::FunctionTemplate> t) {
+  return t->GetFunction(NanGetCurrentContext());
+}
+
+NAN_INLINE NanMaybe<bool> NanSet(
+    v8::Handle<v8::Object> obj
+  , v8::Handle<v8::Value> key
+  , v8::Handle<v8::Value> value) {
+  return obj->Set(NanGetCurrentContext(), key, value);
+}
+
+NAN_INLINE NanMaybe<bool> NanSet(
+    v8::Handle<v8::Object> obj
+  , uint32_t index
+  , v8::Handle<v8::Value> value) {
+  return obj->Set(NanGetCurrentContext(), index, value);
+}
+
+NAN_INLINE NanMaybe<bool> NanForceSet(
+    v8::Handle<v8::Object> obj
+  , v8::Handle<v8::Value> key
+  , v8::Handle<v8::Value> value
+  , v8::PropertyAttribute attribs = v8::None) {
+  return obj->ForceSet(NanGetCurrentContext(), key, value, attribs);
+}
+
+NAN_INLINE NanMaybeLocal<v8::Value> NanGet(
+    v8::Handle<v8::Object> obj
+  , v8::Handle<v8::Value> key) {
+  return obj->Get(NanGetCurrentContext(), key);
+}
+
+NAN_INLINE
+NanMaybeLocal<v8::Value> NanGet(v8::Handle<v8::Object> obj, uint32_t index) {
+  return obj->Get(NanGetCurrentContext(), index);
+}
+
+NAN_INLINE v8::PropertyAttribute NanGetPropertyAttributes(
+    v8::Handle<v8::Object> obj
+  , v8::Handle<v8::Value> key) {
+  return obj->GetPropertyAttributes(NanGetCurrentContext(), key).FromJust();
+}
+
+NAN_INLINE NanMaybe<bool> NanHas(
+    v8::Handle<v8::Object> obj
+  , v8::Handle<v8::String> key) {
+  return obj->Has(NanGetCurrentContext(), key);
+}
+
+NAN_INLINE NanMaybe<bool> NanHas(v8::Handle<v8::Object> obj, uint32_t index) {
+  return obj->Has(NanGetCurrentContext(), index);
+}
+
+NAN_INLINE NanMaybe<bool> NanDelete(
+    v8::Handle<v8::Object> obj
+  , v8::Handle<v8::String> key) {
+  return obj->Delete(NanGetCurrentContext(), key);
+}
+
+NAN_INLINE
+NanMaybe<bool> NanDelete(v8::Handle<v8::Object> obj, uint32_t index) {
+  return obj->Delete(NanGetCurrentContext(), index);
+}
+
+NAN_INLINE NanMaybe<bool> NanSetAccessor(
+    v8::Handle<v8::Object> obj
+  , v8::Handle<v8::String> name
+  , NanGetter getter
+  , NanSetter setter = 0
+  , v8::Handle<v8::Value> data = v8::Handle<v8::Value>()
+  , v8::AccessControl settings = v8::DEFAULT
+  , v8::PropertyAttribute attribute = v8::None) {
+  return obj->SetAccessor(
+       NanGetCurrentContext()
+     , name
+     , getter
+     , setter
+     , data
+     , settings
+     , attribute);
+}
+
+NAN_INLINE
+NanMaybeLocal<v8::Array> NanGetPropertyNames(v8::Handle<v8::Object> obj) {
+  return obj->GetPropertyNames(NanGetCurrentContext());
+}
+
+NAN_INLINE
+NanMaybeLocal<v8::Array> NanGetOwnPropertyNames(v8::Handle<v8::Object> obj) {
+  return obj->GetOwnPropertyNames(NanGetCurrentContext());
+}
+
+NAN_INLINE NanMaybe<bool> NanSetPrototype(
+    v8::Handle<v8::Object> obj
+  , v8::Handle<v8::Value> prototype) {
+  return obj->SetPrototype(NanGetCurrentContext(), prototype);
+}
+
+NAN_INLINE NanMaybeLocal<v8::String> NanObjectProtoToString(
+    v8::Handle<v8::Object> obj) {
+  return obj->ObjectProtoToString(NanGetCurrentContext());
+}
+
+NAN_INLINE NanMaybe<bool> NanHasOwnProperty(
+    v8::Handle<v8::Object> obj
+  , v8::Handle<v8::String> key) {
+  return obj->HasOwnProperty(NanGetCurrentContext(), key);
+}
+
+NAN_INLINE NanMaybe<bool> NanHasRealNamedProperty(
+    v8::Handle<v8::Object> obj
+  , v8::Handle<v8::String> key) {
+  return obj->HasRealNamedProperty(NanGetCurrentContext(), key);
+}
+
+NAN_INLINE NanMaybe<bool> NanHasRealIndexedProperty(
+    v8::Handle<v8::Object> obj
+  , uint32_t index) {
+  return obj->HasRealIndexedProperty(NanGetCurrentContext(), index);
+}
+
+NAN_INLINE NanMaybe<bool> NanHasRealNamedCallbackProperty(
+    v8::Handle<v8::Object> obj
+  , v8::Handle<v8::String> key) {
+  return obj->HasRealNamedCallbackProperty(NanGetCurrentContext(), key);
+}
+
+NAN_INLINE NanMaybeLocal<v8::Value> NanGetRealNamedPropertyInPrototypeChain(
+    v8::Handle<v8::Object> obj
+  , v8::Handle<v8::String> key) {
+  return obj->GetRealNamedPropertyInPrototypeChain(NanGetCurrentContext(), key);
+}
+
+NAN_INLINE NanMaybeLocal<v8::Value> NanGetRealNamedProperty(
+    v8::Handle<v8::Object> obj
+  , v8::Handle<v8::String> key) {
+  return obj->GetRealNamedProperty(NanGetCurrentContext(), key);
+}
+
+NAN_INLINE NanMaybeLocal<v8::Value> NanCallAsFunction(
+    v8::Handle<v8::Object> obj
+  , v8::Handle<v8::Object> recv
+  , int argc
+  , v8::Handle<v8::Value> argv[]) {
+  return obj->CallAsFunction(NanGetCurrentContext(), recv, argc, argv);
+}
+
+NAN_INLINE NanMaybeLocal<v8::Value> NanCallAsConstructor(
+    v8::Handle<v8::Object> obj
+  , int argc, v8::Handle<v8::Value> argv[]) {
+  return obj->CallAsConstructor(NanGetCurrentContext(), argc, argv);
+}
+
+NAN_INLINE
+NanMaybeLocal<v8::String> NanGetSourceLine(v8::Handle<v8::Message> msg) {
+  return msg->GetSourceLine(NanGetCurrentContext());
+}
+
+NAN_INLINE NanMaybe<int> NanGetLineNumber(v8::Handle<v8::Message> msg) {
+  return msg->GetLineNumber(NanGetCurrentContext()).FromJust();
+}
+
+NAN_INLINE NanMaybe<int> NanGetStartColumn(v8::Handle<v8::Message> msg) {
+  return msg->GetStartColumn(NanGetCurrentContext()).FromJust();
+}
+
+NAN_INLINE NanMaybe<int> NanGetEndColumn(v8::Handle<v8::Message> msg) {
+  return msg->GetEndColumn(NanGetCurrentContext()).FromJust();
+}
+
+NAN_INLINE NanMaybeLocal<v8::Object> NanCloneElementAt(
+    v8::Handle<v8::Array> array
+  , uint32_t index) {
+  return array->CloneElementAt(NanGetCurrentContext(), index);
+}
+
+NAN_INLINE NanMaybeLocal<v8::Value> NanStackTrace(v8::TryCatch trycatch) {
+  return trycatch.StackTrace(NanGetCurrentContext());
+}
+
+#else
+
+template<typename T>
+class NanMaybeLocal {
+ public:
+  NAN_INLINE NanMaybeLocal() : val_(v8::Local<T>()) {}
+
+  template<class S>
+# if NODE_MODULE_VERSION >= NODE_0_12_MODULE_VERSION
+  NAN_INLINE NanMaybeLocal(v8::Local<S> that) : val_(that) {}
+# else
+  NAN_INLINE NanMaybeLocal(v8::Local<S> that) :
+      val_(*reinterpret_cast<v8::Local<T>*>(&that)) {}
+# endif
+
+  NAN_INLINE bool IsEmpty() { return val_->IsEmpty(); }
+
+  template<typename S>
+  NAN_INLINE bool ToLocal(v8::Local<S> *out) {
+    *out = val_;
+    return !IsEmpty();
+  }
+
+  NAN_INLINE v8::Local<T> ToLocalChecked() {
+#if defined(V8_ENABLE_CHECKS)
+    assert(!IsEmpty() && "ToLocalChecked is Empty");
+#endif  // V8_ENABLE_CHECKS
+    return val_;
+  }
+
+  template<typename S>
+  NAN_INLINE v8::Local<S> FromMaybe(v8::Local<S> default_value) const {
+    return IsEmpty() ? default_value : val_;
+  }
+
+ private:
+  v8::Local<T> val_;
+};
+
+template<typename T>
+class NanMaybe {
+ public:
+  NAN_INLINE bool IsNothing() const { return !has_value_; }
+  NAN_INLINE bool IsJust() const { return has_value_; }
+
+  NAN_INLINE T FromJust() const {
+#if defined(V8_ENABLE_CHECKS)
+    assert(IsJust() && "FromJust is Nothing");
+#endif  // V8_ENABLE_CHECKS
+    return value_;
+  }
+
+  NAN_INLINE T FromMaybe(const T& default_value) const {
+    return has_value_ ? value_ : default_value;
+  }
+
+  NAN_INLINE bool operator==(const NanMaybe &other) const {
+    return (IsJust() == other.IsJust()) &&
+        (!IsJust() || FromJust() == other.FromJust());
+  }
+
+  NAN_INLINE bool operator!=(const NanMaybe &other) const {
+    return !operator==(other);
+  }
+
+ private:
+  NanMaybe() : has_value_(false) {}
+  explicit NanMaybe(const T& t) : has_value_(true), value_(t) {}
+  bool has_value_;
+  T value_;
+
+  template<typename U>
+  friend NanMaybe<U> NanNothing();
+  template<typename U>
+  friend NanMaybe<U> NanJust(const U& u);
+};
+
+template<typename T>
+inline NanMaybe<T> NanNothing() {
+  return NanMaybe<T>();
+}
+
+template<typename T>
+inline NanMaybe<T> NanJust(const T& t) {
+  return NanMaybe<T>(t);
+}
+
+NAN_INLINE NanMaybeLocal<v8::Boolean> NanToBoolean(v8::Handle<v8::Value> val) {
+  return NanMaybeLocal<v8::Boolean>(val->ToBoolean());
+}
+
+NAN_INLINE NanMaybeLocal<v8::Number> NanToNumber(v8::Handle<v8::Value> val) {
+  return NanMaybeLocal<v8::Number>(val->ToNumber());
+}
+
+NAN_INLINE NanMaybeLocal<v8::String> NanToString(v8::Handle<v8::Value> val) {
+  return NanMaybeLocal<v8::String>(val->ToString());
+}
+
+NAN_INLINE
+NanMaybeLocal<v8::String> NanToDetailString(v8::Handle<v8::Value> val) {
+  return NanMaybeLocal<v8::String>(val->ToDetailString());
+}
+
+NAN_INLINE NanMaybeLocal<v8::Object> NanToObject(v8::Handle<v8::Value> val) {
+  return NanMaybeLocal<v8::Object>(val->ToObject());
+}
+
+NAN_INLINE NanMaybeLocal<v8::Integer> NanToInteger(v8::Handle<v8::Value> val) {
+  return NanMaybeLocal<v8::Integer>(val->ToInteger());
+}
+
+NAN_INLINE NanMaybeLocal<v8::Uint32> NanToUint32(v8::Handle<v8::Value> val) {
+  return NanMaybeLocal<v8::Uint32>(val->ToUint32());
+}
+
+NAN_INLINE NanMaybeLocal<v8::Int32> NanToInt32(v8::Handle<v8::Value> val) {
+  return NanMaybeLocal<v8::Int32>(val->ToInt32());
+}
+
+NAN_INLINE NanMaybe<bool> NanBooleanValue(v8::Handle<v8::Value> val) {
+  return NanJust<bool>(val->BooleanValue());
+}
+
+NAN_INLINE NanMaybe<double> NanNumberValue(v8::Handle<v8::Value> val) {
+  return NanJust<double>(val->NumberValue());
+}
+
+NAN_INLINE NanMaybe<int64_t> NanIntegerValue(v8::Handle<v8::Value> val) {
+  return NanJust<int64_t>(val->IntegerValue());
+}
+
+NAN_INLINE NanMaybe<uint32_t> NanUint32Value(v8::Handle<v8::Value> val) {
+  return NanJust<uint32_t>(val->Uint32Value());
+}
+
+NAN_INLINE NanMaybe<int32_t> NanInt32Value(v8::Handle<v8::Value> val) {
+  return NanJust<int32_t>(val->Int32Value());
+}
+
+NAN_INLINE
+NanMaybe<bool> NanEquals(v8::Handle<v8::Value> a, v8::Handle<v8::Value>(b)) {
+  return NanJust<bool>(a->Equals(b));
+}
+
+template<typename T>
+NAN_INLINE NanMaybeLocal<T> NanNewInstance(v8::Handle<T> h) {
+  return NanMaybeLocal<T>(h->NewInstance());
+}
+
+NAN_INLINE
+NanMaybeLocal<v8::Function> NanGetFunction(v8::Handle<v8::FunctionTemplate> t) {
+  return NanMaybeLocal<v8::Function>(t->GetFunction());
+}
+
+NAN_INLINE NanMaybe<bool> NanSet(
+    v8::Handle<v8::Object> obj
+  , v8::Handle<v8::Value> key
+  , v8::Handle<v8::Value> value) {
+  return NanJust<bool>(obj->Set(key, value));
+}
+
+NAN_INLINE NanMaybe<bool> NanSet(
+    v8::Handle<v8::Object> obj
+  , uint32_t index
+  , v8::Handle<v8::Value> value) {
+  return NanJust<bool>(obj->Set(index, value));
+}
+
+NAN_INLINE NanMaybe<bool> NanForceSet(
+    v8::Handle<v8::Object> obj
+  , v8::Handle<v8::Value> key
+  , v8::Handle<v8::Value> value
+  , v8::PropertyAttribute attribs = v8::None) {
+  return NanJust<bool>(obj->ForceSet(key, value, attribs));
+}
+
+NAN_INLINE NanMaybeLocal<v8::Value> NanGet(
+    v8::Handle<v8::Object> obj
+  , v8::Handle<v8::Value> key) {
+  return NanMaybeLocal<v8::Value>(obj->Get(key));
+}
+
+NAN_INLINE NanMaybeLocal<v8::Value> NanGet(
+    v8::Handle<v8::Object> obj
+  , uint32_t index) {
+  return NanMaybeLocal<v8::Value>(obj->Get(index));
+}
+
+NAN_INLINE NanMaybe<v8::PropertyAttribute> NanGetPropertyAttributes(
+    v8::Handle<v8::Object> obj
+  , v8::Handle<v8::Value> key) {
+  return NanJust<v8::PropertyAttribute>(obj->GetPropertyAttributes(key));
+}
+
+NAN_INLINE NanMaybe<bool> NanHas(
+    v8::Handle<v8::Object> obj
+  , v8::Handle<v8::String> key) {
+  return NanJust<bool>(obj->Has(key));
+}
+
+NAN_INLINE NanMaybe<bool> NanHas(
+    v8::Handle<v8::Object> obj
+  , uint32_t index) {
+  return NanJust<bool>(obj->Has(index));
+}
+
+NAN_INLINE NanMaybe<bool> NanDelete(
+    v8::Handle<v8::Object> obj
+  , v8::Handle<v8::String> key) {
+  return NanJust<bool>(obj->Delete(key));
+}
+
+NAN_INLINE NanMaybe<bool> NanDelete(
+    v8::Handle<v8::Object> obj
+  , uint32_t index) {
+  return NanJust<bool>(obj->Delete(index));
+}
+
+NAN_INLINE NanMaybe<bool> NanSetAccessor(
+    v8::Handle<v8::Object> obj
+  , v8::Handle<v8::String> name
+  , NanGetter getter
+  , NanSetter setter = 0
+  , v8::Handle<v8::Value> data = v8::Handle<v8::Value>()
+  , v8::AccessControl settings = v8::DEFAULT
+  , v8::PropertyAttribute attribute = v8::None) {
+  return NanJust<bool>(obj->SetAccessor(
+       name
+     , getter
+     , setter
+     , data
+     , settings
+     , attribute));
+}
+
+NAN_INLINE
+NanMaybeLocal<v8::Array> NanGetPropertyNames(v8::Handle<v8::Object> obj) {
+  return NanMaybeLocal<v8::Array>(obj->GetPropertyNames());
+}
+
+NAN_INLINE
+NanMaybeLocal<v8::Array> NanGetOwnPropertyNames(v8::Handle<v8::Object> obj) {
+  return NanMaybeLocal<v8::Array>(obj->GetOwnPropertyNames());
+}
+
+NAN_INLINE NanMaybe<bool> NanSetPrototype(
+    v8::Handle<v8::Object> obj
+  , v8::Handle<v8::Value> prototype) {
+  return NanJust<bool>(obj->SetPrototype(prototype));
+}
+
+NAN_INLINE NanMaybeLocal<v8::String> NanObjectProtoToString(
+    v8::Handle<v8::Object> obj) {
+  return NanMaybeLocal<v8::String>(obj->ObjectProtoToString());
+}
+
+NAN_INLINE NanMaybe<bool> NanHasOwnProperty(
+    v8::Handle<v8::Object> obj
+  , v8::Handle<v8::String> key) {
+  return NanJust<bool>(obj->HasOwnProperty(key));
+}
+
+NAN_INLINE NanMaybe<bool> NanHasRealNamedProperty(
+    v8::Handle<v8::Object> obj
+  , v8::Handle<v8::String> key) {
+  return NanJust<bool>(obj->HasRealNamedProperty(key));
+}
+
+NAN_INLINE NanMaybe<bool> NanHasRealIndexedProperty(
+    v8::Handle<v8::Object> obj
+  , uint32_t index) {
+  return NanJust<bool>(obj->HasRealIndexedProperty(index));
+}
+
+NAN_INLINE NanMaybe<bool> NanHasRealNamedCallbackProperty(
+    v8::Handle<v8::Object> obj
+  , v8::Handle<v8::String> key) {
+  return NanJust<bool>(obj->HasRealNamedCallbackProperty(key));
+}
+
+NAN_INLINE NanMaybeLocal<v8::Value> NanGetRealNamedPropertyInPrototypeChain(
+    v8::Handle<v8::Object> obj
+  , v8::Handle<v8::String> key) {
+  return NanMaybeLocal<v8::Value>(
+      obj->GetRealNamedPropertyInPrototypeChain(key));
+}
+
+NAN_INLINE NanMaybeLocal<v8::Value> NanGetRealNamedProperty(
+    v8::Handle<v8::Object> obj
+  , v8::Handle<v8::String> key) {
+  return NanMaybeLocal<v8::Value>(obj->GetRealNamedProperty(key));
+}
+
+NAN_INLINE NanMaybeLocal<v8::Value> NanCallAsFunction(
+    v8::Handle<v8::Object> obj
+  , v8::Handle<v8::Object> recv
+  , int argc
+  , v8::Handle<v8::Value> argv[]) {
+  return NanMaybeLocal<v8::Value>(obj->CallAsFunction(recv, argc, argv));
+}
+
+NAN_INLINE NanMaybeLocal<v8::Value> NanCallAsConstructor(
+    v8::Handle<v8::Object> obj
+  , int argc
+  , v8::Handle<v8::Value> argv[]) {
+  return NanMaybeLocal<v8::Value>(obj->CallAsConstructor(argc, argv));
+}
+
+NAN_INLINE
+NanMaybeLocal<v8::String> NanGetSourceLine(v8::Handle<v8::Message> msg) {
+  return NanMaybeLocal<v8::String>(msg->GetSourceLine());
+}
+
+NAN_INLINE NanMaybe<int> NanGetLineNumber(v8::Handle<v8::Message> msg) {
+  return NanJust<int>(msg->GetLineNumber());
+}
+
+NAN_INLINE NanMaybe<int> NanGetStartColumn(v8::Handle<v8::Message> msg) {
+  return NanJust<int>(msg->GetStartColumn());
+}
+
+NAN_INLINE NanMaybe<int> NanGetEndColumn(v8::Handle<v8::Message> msg) {
+  return NanJust<int>(msg->GetEndColumn());
+}
+
+NAN_INLINE NanMaybeLocal<v8::Object> NanCloneElementAt(
+    v8::Handle<v8::Array> array
+  , uint32_t index) {
+  return NanMaybeLocal<v8::Object>(array->CloneElementAt(index));
+}
+
+NAN_INLINE NanMaybeLocal<v8::Value> NanStackTrace(v8::TryCatch trycatch) {
+  return NanMaybeLocal<v8::Value>(trycatch.StackTrace());
+}
+
+#endif
+
 #include "nan_new.h"  // NOLINT(build/include)
 
 // uv helpers
@@ -219,12 +838,12 @@ NAN_INLINE bool NanBooleanOptionValue(
 ) {
   if (def) {
     return optionsObj.IsEmpty()
-      || !optionsObj->Has(opt)
-      || optionsObj->Get(opt)->BooleanValue();
+      || !NanHas(optionsObj, opt).FromJust()
+      || NanBooleanValue(NanGet(optionsObj, opt).ToLocalChecked()).FromJust();
   } else {
     return !optionsObj.IsEmpty()
-      && optionsObj->Has(opt)
-      && optionsObj->Get(opt)->BooleanValue();
+      && NanHas(optionsObj, opt).FromJust()
+      && NanBooleanValue(NanGet(optionsObj, opt).ToLocalChecked()).FromJust();
   }
 }
 
@@ -241,9 +860,9 @@ NAN_INLINE uint32_t NanUInt32OptionValue(
   , uint32_t def
 ) {
   return !optionsObj.IsEmpty()
-    && optionsObj->Has(opt)
-    && optionsObj->Get(opt)->IsNumber()
-      ? optionsObj->Get(opt)->Uint32Value()
+    && NanHas(optionsObj, opt).FromJust()
+    && NanGet(optionsObj, opt).ToLocalChecked()->IsNumber()
+      ? NanUint32Value(NanGet(optionsObj, opt).ToLocalChecked()).FromJust()
       : def;
 }
 
@@ -261,8 +880,13 @@ NAN_INLINE v8::Local<T> _NanEnsureLocal(v8::Local<T> val) {
 }
 
 template<typename T>
+NAN_INLINE v8::Local<v8::Value> _NanEnsureLocal(NanMaybeLocal<T> val) {
+  return val.ToLocalChecked();
+}
+
+template<typename T>
 NAN_INLINE v8::Local<v8::Value> _NanEnsureLocal(T val) {
-  return NanNew(val);
+  return _NanEnsureLocal(NanNew(val));
 }
 
 /* io.js 1.0  */
@@ -283,9 +907,17 @@ NAN_INLINE v8::Local<v8::Value> _NanEnsureLocal(T val) {
     v8::Isolate::GetCurrent()->SetAddHistogramSampleFunction(cb);
   }
 
+#if defined(V8_MAJOR_VERSION) && (V8_MAJOR_VERSION > 4 ||                      \
+  (V8_MAJOR_VERSION == 4 && defined(V8_MINOR_VERSION) && V8_MINOR_VERSION >= 3))
+  NAN_INLINE bool NanIdleNotification(int idle_time_in_ms) {
+    return v8::Isolate::GetCurrent()->IdleNotificationDeadline(
+        idle_time_in_ms * 0.001);
+  }
+# else
   NAN_INLINE bool NanIdleNotification(int idle_time_in_ms) {
     return v8::Isolate::GetCurrent()->IdleNotification(idle_time_in_ms);
   }
+#endif
 
   NAN_INLINE void NanLowMemoryNotification() {
     v8::Isolate::GetCurrent()->LowMemoryNotification();
@@ -325,7 +957,6 @@ NAN_INLINE v8::Local<v8::Value> _NanEnsureLocal(T val) {
 
 #if (NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION)
 // Node 0.11+ (0.11.12 and below won't compile with these)
-
 # define _NAN_METHOD_ARGS_TYPE const v8::FunctionCallbackInfo<v8::Value>&
 # define _NAN_METHOD_ARGS _NAN_METHOD_ARGS_TYPE args
 # define _NAN_METHOD_RETURN_TYPE void
@@ -396,14 +1027,16 @@ NAN_INLINE v8::Local<v8::Value> _NanEnsureLocal(T val) {
 # define NanEscapeScope(val) scope.Escape(_NanEnsureLocal(val))
 # define NanLocker() v8::Locker locker(v8::Isolate::GetCurrent())
 # define NanUnlocker() v8::Unlocker unlocker(v8::Isolate::GetCurrent())
-# define NanReturnValue(value) return args.GetReturnValue().Set(_NanEnsureLocal(value))
+# define NanReturnValue(value) return args.GetReturnValue().Set(               \
+  _NanEnsureLocal(value))
 # define NanReturnUndefined() return
 # define NanReturnHolder() NanReturnValue(args.Holder())
 # define NanReturnThis() NanReturnValue(args.This())
 # define NanReturnNull() return args.GetReturnValue().SetNull()
 # define NanReturnEmptyString() return args.GetReturnValue().SetEmptyString()
 
-  NAN_INLINE v8::Local<v8::Object> NanObjectWrapHandle(const node::ObjectWrap &obj) {
+  NAN_INLINE
+  v8::Local<v8::Object> NanObjectWrapHandle(const node::ObjectWrap &obj) {
     return const_cast<node::ObjectWrap &>(obj).handle();
   }
 
@@ -496,7 +1129,7 @@ NAN_INLINE v8::Local<v8::Value> _NanEnsureLocal(T val) {
 
   NAN_DEPRECATED NAN_INLINE v8::Local<v8::String> NanSymbol(
       const char* data, int length = -1) {
-    return NanNew<v8::String>(data, length);
+    return NanNew<v8::String>(data, length).ToLocalChecked();
   }
 
   template<typename T>
@@ -593,12 +1226,12 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
     template<typename T, typename P>                                           \
     static void name(const _NanWeakCallbackData<T, P> &data)
 
-# define _NAN_ERROR(fun, errmsg) fun(NanNew<v8::String>(errmsg))
+# define _NAN_ERROR(fun, msg) fun(NanNew<v8::String>(msg).ToLocalChecked())
 
-# define _NAN_THROW_ERROR(fun, errmsg)                                         \
+# define _NAN_THROW_ERROR(fun, msg)                                            \
     do {                                                                       \
       NanScope();                                                              \
-      v8::Isolate::GetCurrent()->ThrowException(_NAN_ERROR(fun, errmsg));      \
+      v8::Isolate::GetCurrent()->ThrowException(_NAN_ERROR(fun, msg));         \
     } while (0);
 
   NAN_INLINE v8::Local<v8::Value> NanError(const char* errmsg) {
@@ -618,9 +1251,12 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
       const char *msg
     , const int errorNumber
   ) {
-    v8::Local<v8::Value> err = v8::Exception::Error(NanNew<v8::String>(msg));
+    v8::Local<v8::Value> err =
+        v8::Exception::Error(NanNew<v8::String>(msg).ToLocalChecked());
     v8::Local<v8::Object> obj = err.As<v8::Object>();
-    obj->Set(NanNew<v8::String>("code"), NanNew<v8::Integer>(errorNumber));
+    NanSet(obj
+      , NanNew<v8::String>("code").ToLocalChecked()
+      , NanNew<v8::Integer>(errorNumber));
     return err;
   }
 
@@ -700,32 +1336,64 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
     );
   }
 
-  NAN_INLINE v8::Local<NanBoundScript> NanCompileScript(
+#if defined(V8_MAJOR_VERSION) && (V8_MAJOR_VERSION > 4 ||                      \
+  (V8_MAJOR_VERSION == 4 && defined(V8_MINOR_VERSION) && V8_MINOR_VERSION >= 3))
+  NAN_INLINE NanMaybeLocal<NanBoundScript> NanCompileScript(
       v8::Local<v8::String> s
     , const v8::ScriptOrigin& origin
   ) {
     v8::ScriptCompiler::Source source(s, origin);
-    return v8::ScriptCompiler::Compile(v8::Isolate::GetCurrent(), &source);
+    return v8::ScriptCompiler::Compile(NanGetCurrentContext(), &source);
   }
 
-  NAN_INLINE v8::Local<NanBoundScript> NanCompileScript(
+  NAN_INLINE NanMaybeLocal<NanBoundScript> NanCompileScript(
       v8::Local<v8::String> s
   ) {
     v8::ScriptCompiler::Source source(s);
-    return v8::ScriptCompiler::Compile(v8::Isolate::GetCurrent(), &source);
+    return v8::ScriptCompiler::Compile(NanGetCurrentContext(), &source);
   }
 
-  NAN_INLINE v8::Local<v8::Value> NanRunScript(
+  NAN_INLINE NanMaybeLocal<v8::Value> NanRunScript(
       v8::Handle<NanUnboundScript> script
   ) {
     return script->BindToCurrentContext()->Run();
   }
 
-  NAN_INLINE v8::Local<v8::Value> NanRunScript(
+  NAN_INLINE NanMaybeLocal<v8::Value> NanRunScript(
       v8::Handle<NanBoundScript> script
   ) {
     return script->Run();
   }
+#else
+  NAN_INLINE NanMaybeLocal<NanBoundScript> NanCompileScript(
+      v8::Local<v8::String> s
+    , const v8::ScriptOrigin& origin
+  ) {
+    v8::ScriptCompiler::Source source(s, origin);
+    return NanMaybeLocal<NanBoundScript>(
+        v8::ScriptCompiler::Compile(v8::Isolate::GetCurrent(), &source));
+  }
+
+  NAN_INLINE NanMaybeLocal<NanBoundScript> NanCompileScript(
+      v8::Local<v8::String> s
+  ) {
+    v8::ScriptCompiler::Source source(s);
+    return NanMaybeLocal<NanBoundScript>(
+        v8::ScriptCompiler::Compile(v8::Isolate::GetCurrent(), &source));
+  }
+
+  NAN_INLINE NanMaybeLocal<v8::Value> NanRunScript(
+      v8::Handle<NanUnboundScript> script
+  ) {
+    return NanMaybeLocal<v8::Value>(script->BindToCurrentContext()->Run());
+  }
+
+  NAN_INLINE NanMaybeLocal<v8::Value> NanRunScript(
+      v8::Handle<NanBoundScript> script
+  ) {
+    return NanMaybeLocal<v8::Value>(script->Run());
+  }
+#endif
 
   NAN_INLINE v8::Local<v8::Value> NanMakeCallback(
       v8::Handle<v8::Object> target
@@ -772,7 +1440,7 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
   class NanAsciiString {
    public:
     NAN_INLINE explicit NanAsciiString(v8::Handle<v8::Value> from) {
-      v8::Local<v8::String> toStr = from->ToString();
+      v8::Local<v8::String> toStr = NanToString(from).ToLocalChecked();
       size = toStr->Length();
       buf = new char[size + 1];
       size = toStr->WriteOneByte(reinterpret_cast<unsigned char*>(buf));
@@ -806,7 +1474,7 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
   class NanUtf8String {
    public:
     NAN_INLINE explicit NanUtf8String(v8::Handle<v8::Value> from) {
-      v8::Local<v8::String> toStr = from->ToString();
+      v8::Local<v8::String> toStr = NanToString(from).ToLocalChecked();
       size = toStr->Utf8Length();
       buf = new char[size + 1];
       toStr->WriteUtf8(buf);
@@ -839,7 +1507,7 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
   class NanUcs2String {
    public:
     NAN_INLINE explicit NanUcs2String(v8::Handle<v8::Value> from) {
-      v8::Local<v8::String> toStr = from->ToString();
+      v8::Local<v8::String> toStr = NanToString(from).ToLocalChecked();
       size = toStr->Length();
       buf = new uint16_t[size + 1];
       toStr->Write(buf);
@@ -871,7 +1539,6 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
 
 #else
 // Node 0.8 and 0.10
-
 # define _NAN_METHOD_ARGS_TYPE const v8::Arguments&
 # define _NAN_METHOD_ARGS _NAN_METHOD_ARGS_TYPE args
 # define _NAN_METHOD_RETURN_TYPE v8::Handle<v8::Value>
@@ -941,7 +1608,8 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
 # define NanReturnNull() return v8::Null()
 # define NanReturnEmptyString() return v8::String::Empty()
 
-  NAN_INLINE v8::Local<v8::Object> NanObjectWrapHandle(const node::ObjectWrap &obj) {
+  NAN_INLINE
+  v8::Local<v8::Object> NanObjectWrapHandle(const node::ObjectWrap &obj) {
     return v8::Local<v8::Object>::New(obj.handle_);
   }
 
@@ -1121,14 +1789,14 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
     template<typename T, typename P>                                           \
     static void name(const _NanWeakCallbackData<T, P> &data)
 
-# define _NAN_ERROR(fun, errmsg)                                               \
+# define _NAN_ERROR(fun, msg)                                                  \
     fun(v8::String::New(errmsg))
 
-# define _NAN_THROW_ERROR(fun, errmsg)                                         \
+# define _NAN_THROW_ERROR(fun, msg)                                            \
     do {                                                                       \
       NanScope();                                                              \
       return v8::Local<v8::Value>::New(                                        \
-        v8::ThrowException(_NAN_ERROR(fun, errmsg)));                          \
+        v8::ThrowException(_NAN_ERROR(fun, msg)));                             \
     } while (0);
 
   NAN_INLINE v8::Local<v8::Value> NanError(const char* errmsg) {
@@ -1248,21 +1916,23 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
     return lctx;
   }
 
-  NAN_INLINE v8::Local<NanBoundScript> NanCompileScript(
+  NAN_INLINE NanMaybeLocal<NanBoundScript> NanCompileScript(
       v8::Local<v8::String> s
     , const v8::ScriptOrigin& origin
   ) {
-    return v8::Script::Compile(s, const_cast<v8::ScriptOrigin *>(&origin));
+    return NanMaybeLocal<NanBoundScript>(
+        v8::Script::Compile(s, const_cast<v8::ScriptOrigin *>(&origin)));
   }
 
-  NAN_INLINE v8::Local<NanBoundScript> NanCompileScript(
+  NAN_INLINE NanMaybeLocal<NanBoundScript> NanCompileScript(
     v8::Local<v8::String> s
   ) {
-    return v8::Script::Compile(s);
+    return NanMaybeLocal<NanBoundScript>(v8::Script::Compile(s));
   }
 
-  NAN_INLINE v8::Local<v8::Value> NanRunScript(v8::Handle<v8::Script> script) {
-    return script->Run();
+  NAN_INLINE
+  NanMaybeLocal<v8::Value> NanRunScript(v8::Handle<v8::Script> script) {
+    return NanMaybeLocal<v8::Value>(script->Run());
   }
 
   NAN_INLINE v8::Local<v8::Value> NanMakeCallback(
@@ -1325,7 +1995,7 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
   class NanAsciiString {
    public:
     NAN_INLINE explicit NanAsciiString(v8::Handle<v8::Value> from) {
-      v8::Local<v8::String> toStr = from->ToString();
+      v8::Local<v8::String> toStr = NanToString(from).ToLocalChecked();
       size = toStr->Length();
       buf = new char[size + 1];
       size = toStr->WriteAscii(buf);
@@ -1359,7 +2029,7 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
   class NanUtf8String {
    public:
     NAN_INLINE explicit NanUtf8String(v8::Handle<v8::Value> from) {
-      v8::Local<v8::String> toStr = from->ToString();
+      v8::Local<v8::String> toStr = NanToString(from).ToLocalChecked();
       size = toStr->Utf8Length();
       buf = new char[size + 1];
       toStr->WriteUtf8(buf);
@@ -1392,7 +2062,7 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
   class NanUcs2String {
    public:
     NAN_INLINE explicit NanUcs2String(v8::Handle<v8::Value> from) {
-      v8::Local<v8::String> toStr = from->ToString();
+      v8::Local<v8::String> toStr = NanToString(from).ToLocalChecked();
       size = toStr->Length();
       buf = new uint16_t[size + 1];
       toStr->Write(buf);
@@ -1504,7 +2174,7 @@ class NanCallback {
 
   NAN_INLINE void SetFunction(const v8::Handle<v8::Function> &fn) {
     NanScope();
-    NanNew(handle)->Set(kCallbackIndex, fn);
+    NanSet(NanNew(handle), kCallbackIndex, fn);
   }
 
   NAN_INLINE v8::Local<v8::Function> GetFunction() const {
@@ -1583,7 +2253,7 @@ class NanCallback {
 #endif
 #endif
   }
-};
+};  // NOLINT(readability/braces)
 
 /* abstract */ class NanAsyncWorker {
  public:
@@ -1621,13 +2291,14 @@ class NanCallback {
   NAN_INLINE void SaveToPersistent(
       const char *key, const v8::Local<v8::Object> &obj) {
     v8::Local<v8::Object> handle = NanNew(persistentHandle);
-    handle->Set(NanNew<v8::String>(key), obj);
+    NanSet(handle, NanNew<v8::String>(key).ToLocalChecked(), obj);
   }
 
   v8::Local<v8::Object> GetFromPersistent(const char *key) const {
     NanEscapableScope();
     v8::Local<v8::Object> handle = NanNew(persistentHandle);
-    return NanEscapeScope(handle->Get(NanNew(key)).As<v8::Object>());
+    return NanEscapeScope(
+        handle->Get(NanNew(key).ToLocalChecked()).As<v8::Object>());
   }
 
   virtual void Execute() = 0;
@@ -1650,7 +2321,7 @@ class NanCallback {
     NanScope();
 
     v8::Local<v8::Value> argv[] = {
-        v8::Exception::Error(NanNew<v8::String>(ErrorMessage()))
+      v8::Exception::Error(NanNew<v8::String>(ErrorMessage()).ToLocalChecked())
     };
     callback->Call(1, argv);
   }
@@ -2091,7 +2762,7 @@ NAN_INLINE ssize_t NanDecodeWrite(
     return data;
   }
 
-  v8::Local<v8::String> toStr = from->ToString();
+  v8::Local<v8::String> toStr = NanToString(from).ToLocalChecked();
 
   char *to = static_cast<char *>(buf);
 
@@ -2279,7 +2950,7 @@ inline
 void
 NanExport(v8::Handle<v8::Object> target, const char * name,
     NanFunctionCallback f) {
-  target->Set(NanNew<v8::String>(name),
+  NanSet(target, NanNew<v8::String>(name).ToLocalChecked(),
       NanNew<v8::FunctionTemplate>(f)->GetFunction());
 }
 
@@ -2287,7 +2958,7 @@ NanExport(v8::Handle<v8::Object> target, const char * name,
 
 struct NanTap {
   explicit NanTap(v8::Handle<v8::Value> t) : t_() {
-    NanAssignPersistent(t_, t->ToObject());
+    NanAssignPersistent(t_, NanToObject(t).ToLocalChecked());
   }
 
   ~NanTap() { NanDisposePersistent(t_); }  // not sure if neccessary
@@ -2300,7 +2971,7 @@ struct NanTap {
   inline void ok(bool isOk, const char * msg = NULL) {
     v8::Handle<v8::Value> args[2];
     args[0] = NanNew(isOk);
-    if (msg) args[1] = NanNew(msg);
+    if (msg) args[1] = NanNew(msg).ToLocalChecked();
     NanMakeCallback(NanNew(t_), "ok", msg ? 2 : 1, args);
   }
 

--- a/nan_implementation_12_inl.h
+++ b/nan_implementation_12_inl.h
@@ -59,10 +59,19 @@ Factory<v8::Context>::New( v8::ExtensionConfiguration* extensions
 
 //=== Date =====================================================================
 
+#if defined(V8_MAJOR_VERSION) && (V8_MAJOR_VERSION > 4 ||                      \
+  (V8_MAJOR_VERSION == 4 && defined(V8_MINOR_VERSION) && V8_MINOR_VERSION >= 3))
 Factory<v8::Date>::return_t
 Factory<v8::Date>::New(double value) {
-  return v8::Date::New(v8::Isolate::GetCurrent(), value).As<v8::Date>();
+  return v8::Date::New(NanGetCurrentContext(), value).As<v8::Date>();
 }
+#else
+Factory<v8::Date>::return_t
+Factory<v8::Date>::New(double value) {
+  return Factory<v8::Date>::return_t(
+      v8::Date::New(v8::Isolate::GetCurrent(), value).As<v8::Date>());
+}
+#endif
 
 //=== External =================================================================
 
@@ -150,15 +159,27 @@ Factory<v8::ObjectTemplate>::New() {
 
 //=== RegExp ===================================================================
 
+#if defined(V8_MAJOR_VERSION) && (V8_MAJOR_VERSION > 4 ||                      \
+  (V8_MAJOR_VERSION == 4 && defined(V8_MINOR_VERSION) && V8_MINOR_VERSION >= 3))
 Factory<v8::RegExp>::return_t
 Factory<v8::RegExp>::New(
     v8::Handle<v8::String> pattern
   , v8::RegExp::Flags flags) {
-  return v8::RegExp::New(pattern, flags);
+  return v8::RegExp::New(NanGetCurrentContext(), pattern, flags);
 }
+#else
+Factory<v8::RegExp>::return_t
+Factory<v8::RegExp>::New(
+    v8::Handle<v8::String> pattern
+  , v8::RegExp::Flags flags) {
+  return Factory<v8::RegExp>::return_t(v8::RegExp::New(pattern, flags));
+}
+#endif
 
 //=== Script ===================================================================
 
+#if defined(V8_MAJOR_VERSION) && (V8_MAJOR_VERSION > 4 ||                      \
+  (V8_MAJOR_VERSION == 4 && defined(V8_MINOR_VERSION) && V8_MINOR_VERSION >= 3))
 Factory<v8::Script>::return_t
 Factory<v8::Script>::New( v8::Local<v8::String> source) {
   v8::ScriptCompiler::Source src(source);
@@ -171,6 +192,22 @@ Factory<v8::Script>::New( v8::Local<v8::String> source
   v8::ScriptCompiler::Source src(source, origin);
   return v8::ScriptCompiler::Compile(v8::Isolate::GetCurrent(), &src);
 }
+#else
+Factory<v8::Script>::return_t
+Factory<v8::Script>::New( v8::Local<v8::String> source) {
+  v8::ScriptCompiler::Source src(source);
+  return Factory<v8::Script>::return_t(
+      v8::ScriptCompiler::Compile(v8::Isolate::GetCurrent(), &src));
+}
+
+Factory<v8::Script>::return_t
+Factory<v8::Script>::New( v8::Local<v8::String> source
+                        , v8::ScriptOrigin const& origin) {
+  v8::ScriptCompiler::Source src(source, origin);
+  return Factory<v8::Script>::return_t(
+      v8::ScriptCompiler::Compile(v8::Isolate::GetCurrent(), &src));
+}
+#endif
 
 //=== Signature ================================================================
 
@@ -183,9 +220,12 @@ Factory<v8::Signature>::New(Factory<v8::Signature>::FTH receiver) {
 
 Factory<v8::String>::return_t
 Factory<v8::String>::New() {
-  return v8::String::Empty(v8::Isolate::GetCurrent());
+  return Factory<v8::String>::return_t(
+      v8::String::Empty(v8::Isolate::GetCurrent()));
 }
 
+#if defined(V8_MAJOR_VERSION) && (V8_MAJOR_VERSION > 4 ||                      \
+  (V8_MAJOR_VERSION == 4 && defined(V8_MINOR_VERSION) && V8_MINOR_VERSION >= 3))
 Factory<v8::String>::return_t
 Factory<v8::String>::New(const char * value, int length) {
   return v8::String::NewFromUtf8(v8::Isolate::GetCurrent(), value,
@@ -220,6 +260,59 @@ Factory<v8::String>::return_t
 Factory<v8::String>::New(NanExternalOneByteStringResource * value) {
   return v8::String::NewExternal(v8::Isolate::GetCurrent(), value);
 }
+#else
+Factory<v8::String>::return_t
+Factory<v8::String>::New(const char * value, int length) {
+  return Factory<v8::String>::return_t(
+      v8::String::NewFromUtf8(
+          v8::Isolate::GetCurrent()
+        , value
+        , v8::String::kNormalString
+        , length));
+}
+
+Factory<v8::String>::return_t
+Factory<v8::String>::New(std::string const& value) {
+  assert(value.size() <= INT_MAX && "string too long");
+  return Factory<v8::String>::return_t(
+      v8::String::NewFromUtf8(
+          v8::Isolate::GetCurrent()
+        , value.data()
+        , v8::String::kNormalString
+        , static_cast<int>(value.size())));
+}
+
+Factory<v8::String>::return_t
+Factory<v8::String>::New(const uint8_t * value, int length) {
+  return Factory<v8::String>::return_t(
+      v8::String::NewFromOneByte(
+          v8::Isolate::GetCurrent()
+        , value
+        , v8::String::kNormalString, length));
+}
+
+Factory<v8::String>::return_t
+Factory<v8::String>::New(const uint16_t * value, int length) {
+  return Factory<v8::String>::return_t(
+      v8::String::NewFromTwoByte(
+          v8::Isolate::GetCurrent()
+        , value
+        , v8::String::kNormalString
+        , length));
+}
+
+Factory<v8::String>::return_t
+Factory<v8::String>::New(v8::String::ExternalStringResource * value) {
+  return Factory<v8::String>::return_t(
+      v8::String::NewExternal(v8::Isolate::GetCurrent(), value));
+}
+
+Factory<v8::String>::return_t
+Factory<v8::String>::New(NanExternalOneByteStringResource * value) {
+  return Factory<v8::String>::return_t(
+      v8::String::NewExternal(v8::Isolate::GetCurrent(), value));
+}
+#endif
 
 //=== String Object ============================================================
 

--- a/nan_implementation_pre_12_inl.h
+++ b/nan_implementation_pre_12_inl.h
@@ -69,7 +69,7 @@ Factory<v8::Context>::New( v8::ExtensionConfiguration* extensions
 
 Factory<v8::Date>::return_t
 Factory<v8::Date>::New(double value) {
-  return v8::Date::New(value).As<v8::Date>();
+  return Factory<v8::Date>::return_t(v8::Date::New(value).As<v8::Date>());
 }
 
 //=== External =================================================================
@@ -163,19 +163,20 @@ Factory<v8::RegExp>::return_t
 Factory<v8::RegExp>::New(
     v8::Handle<v8::String> pattern
   , v8::RegExp::Flags flags) {
-  return v8::RegExp::New(pattern, flags);
+  return Factory<v8::RegExp>::return_t(v8::RegExp::New(pattern, flags));
 }
 
 //=== Script ===================================================================
 
 Factory<v8::Script>::return_t
 Factory<v8::Script>::New( v8::Local<v8::String> source) {
-  return v8::Script::New(source);
+  return Factory<v8::Script>::return_t(v8::Script::New(source));
 }
 Factory<v8::Script>::return_t
 Factory<v8::Script>::New( v8::Local<v8::String> source
                         , v8::ScriptOrigin const& origin) {
-  return v8::Script::New(source, const_cast<v8::ScriptOrigin*>(&origin));
+  return Factory<v8::Script>::return_t(
+      v8::Script::New(source, const_cast<v8::ScriptOrigin*>(&origin)));
 }
 
 //=== Signature ================================================================
@@ -189,18 +190,19 @@ Factory<v8::Signature>::New(Factory<v8::Signature>::FTH receiver) {
 
 Factory<v8::String>::return_t
 Factory<v8::String>::New() {
-  return v8::String::Empty();
+  return Factory<v8::String>::return_t(v8::String::Empty());
 }
 
 Factory<v8::String>::return_t
 Factory<v8::String>::New(const char * value, int length) {
-  return v8::String::New(value, length);
+  return Factory<v8::String>::return_t(v8::String::New(value, length));
 }
 
 Factory<v8::String>::return_t
 Factory<v8::String>::New(std::string const& value) {
   assert(value.size() <= INT_MAX && "string too long");
-  return v8::String::New( value.data(), static_cast<int>(value.size()));
+  return Factory<v8::String>::return_t(
+      v8::String::New( value.data(), static_cast<int>(value.size())));
 }
 
 inline
@@ -217,7 +219,7 @@ widenString(std::vector<uint16_t> *ws, const uint8_t *s, int l = -1) {
 
 Factory<v8::String>::return_t
 Factory<v8::String>::New(const uint16_t * value, int length) {
-  return v8::String::New(value, length);
+  return Factory<v8::String>::return_t(v8::String::New(value, length));
 }
 
 Factory<v8::String>::return_t
@@ -225,21 +227,21 @@ Factory<v8::String>::New(const uint8_t * value, int length) {
   std::vector<uint16_t> wideString;
   widenString(&wideString, value, length);
   if (wideString.size() == 0) {
-    return v8::String::Empty();
+    return Factory<v8::String>::return_t(v8::String::Empty());
   } else {
-    return v8::String::New(&wideString.front()
-         , static_cast<int>(wideString.size()));
+    return Factory<v8::String>::return_t(v8::String::New(&wideString.front()
+         , static_cast<int>(wideString.size())));
   }
 }
 
 Factory<v8::String>::return_t
 Factory<v8::String>::New(v8::String::ExternalStringResource * value) {
-  return v8::String::NewExternal(value);
+  return Factory<v8::String>::return_t(v8::String::NewExternal(value));
 }
 
 Factory<v8::String>::return_t
 Factory<v8::String>::New(v8::String::ExternalAsciiStringResource * value) {
-  return v8::String::NewExternal(value);
+  return Factory<v8::String>::return_t(v8::String::NewExternal(value));
 }
 
 //=== String Object ============================================================

--- a/nan_new.h
+++ b/nan_new.h
@@ -25,19 +25,31 @@ template <typename T> v8::Local<T> To(v8::Handle<v8::Integer> i);
 template <>
 inline
 v8::Local<v8::Integer>
-To<v8::Integer>(v8::Handle<v8::Integer> i) { return i->ToInteger(); }
+To<v8::Integer>(v8::Handle<v8::Integer> i) {
+  return NanToInteger(i).ToLocalChecked();
+}
 
 template <>
 inline
 v8::Local<v8::Int32>
-To<v8::Int32>(v8::Handle<v8::Integer> i)   { return i->ToInt32(); }
+To<v8::Int32>(v8::Handle<v8::Integer> i) {
+  return NanToInt32(i).ToLocalChecked();
+}
 
 template <>
 inline
 v8::Local<v8::Uint32>
-To<v8::Uint32>(v8::Handle<v8::Integer> i)  { return i->ToUint32(); }
+To<v8::Uint32>(v8::Handle<v8::Integer> i) {
+  return NanToUint32(i).ToLocalChecked();
+}
 
-template <typename T> struct FactoryBase { typedef v8::Local<T> return_t; };
+template <typename T> struct FactoryBase {
+  typedef v8::Local<T> return_t;
+};
+
+template <typename T> struct MaybeFactoryBase {
+  typedef NanMaybeLocal<T> return_t;
+};
 
 template <typename T> struct Factory;
 
@@ -67,7 +79,7 @@ struct Factory<v8::Context> : FactoryBase<v8::Context> {
 };
 
 template <>
-struct Factory<v8::Date> : FactoryBase<v8::Date> {
+struct Factory<v8::Date> : MaybeFactoryBase<v8::Date> {
   static inline return_t New(double value);
 };
 
@@ -133,13 +145,13 @@ struct Factory<v8::ObjectTemplate> : FactoryBase<v8::ObjectTemplate> {
 };
 
 template <>
-struct Factory<v8::RegExp> : FactoryBase<v8::RegExp> {
+struct Factory<v8::RegExp> : MaybeFactoryBase<v8::RegExp> {
   static inline return_t New(
       v8::Handle<v8::String> pattern, v8::RegExp::Flags flags);
 };
 
 template <>
-struct Factory<v8::Script> : FactoryBase<v8::Script> {
+struct Factory<v8::Script> : MaybeFactoryBase<v8::Script> {
   static inline return_t New( v8::Local<v8::String> source);
   static inline return_t New( v8::Local<v8::String> source
                             , v8::ScriptOrigin const& origin);
@@ -152,7 +164,7 @@ struct Factory<v8::Signature> : FactoryBase<v8::Signature> {
 };
 
 template <>
-struct Factory<v8::String> : FactoryBase<v8::String> {
+struct Factory<v8::String> : MaybeFactoryBase<v8::String> {
   static inline return_t New();
   static inline return_t New(const char *value, int length = -1);
   static inline return_t New(const uint16_t *value, int length = -1);
@@ -177,7 +189,7 @@ struct Factory<v8::StringObject> : FactoryBase<v8::StringObject> {
 namespace NanIntern {
 
 template <>
-struct Factory<v8::UnboundScript> : FactoryBase<v8::UnboundScript> {
+struct Factory<v8::UnboundScript> : MaybeFactoryBase<v8::UnboundScript> {
   static inline return_t New( v8::Local<v8::String> source);
   static inline return_t New( v8::Local<v8::String> source
                             , v8::ScriptOrigin const& origin);

--- a/nan_string_bytes.h
+++ b/nan_string_bytes.h
@@ -233,7 +233,7 @@ static Local<Value> Encode(const char* buf,
                            enum Nan::Encoding encoding) {
   assert(buflen <= node::Buffer::kMaxLength);
   if (!buflen && encoding != Nan::BUFFER)
-    return NanNew("");
+    return NanNew("").ToLocalChecked();
 
   Local<String> val;
   switch (encoding) {
@@ -244,15 +244,15 @@ static Local<Value> Encode(const char* buf,
       if (contains_non_ascii(buf, buflen)) {
         char* out = new char[buflen];
         force_ascii(buf, out, buflen);
-        val = NanNew<String>(out, buflen);
+        val = NanNew<String>(out, buflen).ToLocalChecked();
         delete[] out;
       } else {
-        val = NanNew<String>(buf, buflen);
+        val = NanNew<String>(buf, buflen).ToLocalChecked();
       }
       break;
 
     case Nan::UTF8:
-      val = NanNew<String>(buf, buflen);
+      val = NanNew<String>(buf, buflen).ToLocalChecked();
       break;
 
     case Nan::BINARY: {
@@ -263,7 +263,7 @@ static Local<Value> Encode(const char* buf,
         // XXX is the following line platform independent?
         twobytebuf[i] = cbuf[i];
       }
-      val = NanNew<String>(twobytebuf, buflen);
+      val = NanNew<String>(twobytebuf, buflen).ToLocalChecked();
       delete[] twobytebuf;
       break;
     }
@@ -275,14 +275,14 @@ static Local<Value> Encode(const char* buf,
       size_t written = base64_encode(buf, buflen, dst, dlen);
       assert(written == dlen);
 
-      val = NanNew<String>(dst, dlen);
+      val = NanNew<String>(dst, dlen).ToLocalChecked();
       delete[] dst;
       break;
     }
 
     case Nan::UCS2: {
       const uint16_t* data = reinterpret_cast<const uint16_t*>(buf);
-      val = NanNew<String>(data, buflen / 2);
+      val = NanNew<String>(data, buflen / 2).ToLocalChecked();
       break;
     }
 
@@ -292,7 +292,7 @@ static Local<Value> Encode(const char* buf,
       size_t written = hex_encode(buf, buflen, dst, dlen);
       assert(written == dlen);
 
-      val = NanNew<String>(dst, dlen);
+      val = NanNew<String>(dst, dlen).ToLocalChecked();
       delete[] dst;
       break;
     }

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "bindings": "~1.2.1",
     "node-gyp": "~1.0.2",
     "pangyp": "~2.0.1",
-    "tap": "~0.5.0",
+    "tap": "~0.7.1",
     "xtend": "~4.0.0"
   },
   "license": "MIT"

--- a/test/binding.gyp
+++ b/test/binding.gyp
@@ -100,4 +100,8 @@
         "target_name" : "threadlocal"
       , "sources"     : [ "cpp/threadlocal.cpp" ]
     }
+    , {
+        "target_name" : "converters"
+      , "sources"     : [ "cpp/converters.cpp" ]
+    }
 ]}

--- a/test/cpp/asyncprogressworker.cpp
+++ b/test/cpp/asyncprogressworker.cpp
@@ -52,14 +52,14 @@ NAN_METHOD(DoProgress) {
   NanAsyncQueueWorker(new ProgressWorker(
       callback
     , progress
-    , args[0]->Uint32Value()
-    , args[1]->Uint32Value()));
+    , NanUint32Value(args[0]).FromJust()
+    , NanUint32Value(args[1]).FromJust()));
   NanReturnUndefined();
 }
 
 void Init(v8::Handle<v8::Object> exports) {
-  exports->Set(
-      NanNew<v8::String>("a")
+  NanSet(exports
+    , NanNew<v8::String>("a").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(DoProgress)->GetFunction());
 }
 

--- a/test/cpp/asyncworker.cpp
+++ b/test/cpp/asyncworker.cpp
@@ -29,13 +29,14 @@ class SleepWorker : public NanAsyncWorker {
 NAN_METHOD(DoSleep) {
   NanScope();
   NanCallback *callback = new NanCallback(args[1].As<v8::Function>());
-  NanAsyncQueueWorker(new SleepWorker(callback, args[0]->Uint32Value()));
+  NanAsyncQueueWorker(
+      new SleepWorker(callback, NanUint32Value(args[0]).FromJust()));
   NanReturnUndefined();
 }
 
 void Init(v8::Handle<v8::Object> exports) {
-  exports->Set(
-      NanNew<v8::String>("a")
+  NanSet(exports
+    , NanNew<v8::String>("a").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(DoSleep)->GetFunction());
 }
 

--- a/test/cpp/asyncworkererror.cpp
+++ b/test/cpp/asyncworkererror.cpp
@@ -26,7 +26,9 @@ NAN_METHOD(Work) {
 }
 
 void Init (v8::Handle<v8::Object> exports) {
-  exports->Set(NanNew("a"), NanNew<v8::FunctionTemplate>(Work)->GetFunction());
+  NanSet(exports
+    , NanNew("a").ToLocalChecked()
+    , NanNew<v8::FunctionTemplate>(Work)->GetFunction());
 }
 
 NODE_MODULE(asyncworkererror, Init)

--- a/test/cpp/bufferworkerpersistent.cpp
+++ b/test/cpp/bufferworkerpersistent.cpp
@@ -49,14 +49,16 @@ NAN_METHOD(DoSleep) {
   v8::Local<v8::Object> bufferHandle = args[1].As<v8::Object>();
   NanCallback *callback = new NanCallback(args[2].As<v8::Function>());
   assert(!callback->IsEmpty() && "Callback shoud not be empty");
-  NanAsyncQueueWorker(
-      new BufferWorker(callback, args[0]->Uint32Value(), bufferHandle));
+  NanAsyncQueueWorker(new BufferWorker(
+      callback
+    , NanUint32Value(args[0]).FromJust()
+    , bufferHandle));
   NanReturnUndefined();
 }
 
 void Init(v8::Handle<v8::Object> exports) {
-  exports->Set(
-      NanNew<v8::String>("a")
+  NanSet(exports
+    , NanNew<v8::String>("a").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(DoSleep)->GetFunction());
 }
 

--- a/test/cpp/converters.cpp
+++ b/test/cpp/converters.cpp
@@ -1,0 +1,131 @@
+/*********************************************************************
+ * NAN - Native Abstractions for Node.js
+ *
+ * Copyright (c) 2015 NAN contributors
+ *
+ * MIT License <https://github.com/rvagg/nan/blob/master/LICENSE.md>
+ ********************************************************************/
+
+#include <nan.h>
+
+NAN_METHOD(ToBoolean) {
+  NanScope();
+  NanReturnValue(NanToBoolean(args[0]).ToLocalChecked());
+}
+
+NAN_METHOD(ToNumber) {
+  NanScope();
+  NanReturnValue(NanToNumber(args[0]).ToLocalChecked());
+}
+
+NAN_METHOD(ToString) {
+  NanScope();
+  NanReturnValue(NanToString(args[0]).ToLocalChecked());
+}
+
+NAN_METHOD(ToDetailString) {
+  NanScope();
+  NanReturnValue(NanToDetailString(args[0]).ToLocalChecked());
+}
+
+NAN_METHOD(ToObject) {
+  NanScope();
+  NanReturnValue(NanToObject(args[0]).ToLocalChecked());
+}
+
+NAN_METHOD(ToInteger) {
+  NanScope();
+  NanReturnValue(NanToInteger(args[0]).ToLocalChecked());
+}
+
+NAN_METHOD(ToUint32) {
+  NanScope();
+  NanReturnValue(NanToUint32(args[0]).ToLocalChecked());
+}
+
+NAN_METHOD(ToInt32) {
+  NanScope();
+  NanReturnValue(NanToInt32(args[0]).ToLocalChecked());
+}
+
+NAN_METHOD(BooleanValue) {
+  NanScope();
+  NanReturnValue(NanNew(NanBooleanValue(args[0]).FromJust()));
+}
+
+NAN_METHOD(NumberValue) {
+  NanScope();
+  NanReturnValue(NanNew(NanNumberValue(args[0]).FromJust()));
+}
+
+NAN_METHOD(IntegerValue) {
+  NanScope();
+  NanReturnValue(NanNew<v8::Integer>(static_cast<int32_t>(NanIntegerValue(args[0]).FromJust())));
+}
+
+NAN_METHOD(Uint32Value) {
+  NanScope();
+  NanReturnValue(NanNew<v8::Uint32>(NanUint32Value(args[0]).FromJust()));
+}
+
+NAN_METHOD(Int32Value) {
+  NanScope();
+  NanReturnValue(NanNew<v8::Int32>(NanInt32Value(args[0]).FromJust()));
+}
+
+void Init (v8::Handle<v8::Object> target) {
+  NanSet(target
+    , NanNew<v8::String>("toBoolean").ToLocalChecked()
+    , NanNew<v8::FunctionTemplate>(ToBoolean)->GetFunction()
+  );
+  NanSet(target
+    , NanNew<v8::String>("toNumber").ToLocalChecked()
+    , NanNew<v8::FunctionTemplate>(ToNumber)->GetFunction()
+  );
+  NanSet(target
+    , NanNew<v8::String>("toString").ToLocalChecked()
+    , NanNew<v8::FunctionTemplate>(ToString)->GetFunction()
+  );
+  NanSet(target
+    , NanNew<v8::String>("toDetailString").ToLocalChecked()
+    , NanNew<v8::FunctionTemplate>(ToDetailString)->GetFunction()
+  );
+  NanSet(target
+    , NanNew<v8::String>("toObject").ToLocalChecked()
+    , NanNew<v8::FunctionTemplate>(ToObject)->GetFunction()
+  );
+  NanSet(target
+    , NanNew<v8::String>("toInteger").ToLocalChecked()
+    , NanNew<v8::FunctionTemplate>(ToInteger)->GetFunction()
+  );
+  NanSet(target
+    , NanNew<v8::String>("toUint32").ToLocalChecked()
+    , NanNew<v8::FunctionTemplate>(ToUint32)->GetFunction()
+  );
+  NanSet(target
+    , NanNew<v8::String>("toInt32").ToLocalChecked()
+    , NanNew<v8::FunctionTemplate>(ToInt32)->GetFunction()
+  );
+  NanSet(target
+    , NanNew<v8::String>("booleanValue").ToLocalChecked()
+    , NanNew<v8::FunctionTemplate>(BooleanValue)->GetFunction()
+  );
+  NanSet(target
+    , NanNew<v8::String>("numberValue").ToLocalChecked()
+    , NanNew<v8::FunctionTemplate>(NumberValue)->GetFunction()
+  );
+  NanSet(target
+    , NanNew<v8::String>("integerValue").ToLocalChecked()
+    , NanNew<v8::FunctionTemplate>(IntegerValue)->GetFunction()
+  );
+  NanSet(target
+    , NanNew<v8::String>("uint32Value").ToLocalChecked()
+    , NanNew<v8::FunctionTemplate>(Uint32Value)->GetFunction()
+  );
+  NanSet(target
+    , NanNew<v8::String>("int32Value").ToLocalChecked()
+    , NanNew<v8::FunctionTemplate>(Int32Value)->GetFunction()
+  );
+}
+
+NODE_MODULE(converters, Init)

--- a/test/cpp/gc.cpp
+++ b/test/cpp/gc.cpp
@@ -11,12 +11,14 @@
 static v8::Persistent<v8::Function> callback;
 
 NAN_GC_CALLBACK(gcPrologueCallback) {
-  v8::Local<v8::Value> argv[] = {NanNew<v8::String>("prologue")};
+  v8::Local<v8::Value> argv[] =
+      {NanNew<v8::String>("prologue").ToLocalChecked()};
   NanMakeCallback(NanGetCurrentContext()->Global(), NanNew(callback), 1, argv);
 }
 
 NAN_GC_CALLBACK(gcEpilogueCallback) {
-  v8::Local<v8::Value> argv[] = {NanNew<v8::String>("epilogue")};
+  v8::Local<v8::Value> argv[] =
+      {NanNew<v8::String>("epilogue").ToLocalChecked()};
   NanMakeCallback(NanGetCurrentContext()->Global(), NanNew(callback), 1, argv);
 }
 
@@ -29,8 +31,8 @@ NAN_METHOD(Hook) {
 }
 
 void Init (v8::Handle<v8::Object> target) {
-  target->Set(
-      NanNew<v8::String>("hook")
+  NanSet(target
+    , NanNew<v8::String>("hook").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(Hook)->GetFunction()
   );
 }

--- a/test/cpp/isolatedata.cpp
+++ b/test/cpp/isolatedata.cpp
@@ -29,8 +29,8 @@ NAN_METHOD(SetAndGet) {
 }
 
 void Init (v8::Handle<v8::Object> target) {
-  target->Set(
-      NanNew<v8::String>("setAndGet")
+  NanSet(target
+    , NanNew<v8::String>("setAndGet").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(SetAndGet)->GetFunction()
   );
 }

--- a/test/cpp/makecallback.cpp
+++ b/test/cpp/makecallback.cpp
@@ -9,16 +9,16 @@
 #include <nan.h>
 
 class MyObject : public node::ObjectWrap {
-public:
-    static void Init(v8::Handle<v8::Object> exports);
+ public:
+  static void Init(v8::Handle<v8::Object> exports);
 
-private:
-    MyObject();
-    ~MyObject();
+ private:
+  MyObject();
+  ~MyObject();
 
-    static NAN_METHOD(New);
-    static NAN_METHOD(CallEmit);
-    static v8::Persistent<v8::Function> constructor;
+  static NAN_METHOD(New);
+  static NAN_METHOD(CallEmit);
+  static v8::Persistent<v8::Function> constructor;
 };
 
 v8::Persistent<v8::Function> MyObject::constructor;
@@ -30,45 +30,45 @@ MyObject::~MyObject() {
 }
 
 void MyObject::Init(v8::Handle<v8::Object> exports) {
-    NanScope();
+  NanScope();
 
-    // Prepare constructor template
-    v8::Local<v8::FunctionTemplate> tpl = NanNew<v8::FunctionTemplate>(New);
-    tpl->SetClassName(NanNew<v8::String>("MyObject"));
-    tpl->InstanceTemplate()->SetInternalFieldCount(1);
+  // Prepare constructor template
+  v8::Local<v8::FunctionTemplate> tpl = NanNew<v8::FunctionTemplate>(New);
+  tpl->SetClassName(NanNew<v8::String>("MyObject").ToLocalChecked());
+  tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
-    NODE_SET_PROTOTYPE_METHOD(tpl, "call_emit", CallEmit);
+  NODE_SET_PROTOTYPE_METHOD(tpl, "call_emit", CallEmit);
 
-    NanAssignPersistent<v8::Function>(constructor, tpl->GetFunction());
-    exports->Set(NanNew<v8::String>("MyObject"), tpl->GetFunction());
+  NanAssignPersistent<v8::Function>(constructor, tpl->GetFunction());
+  NanSet(exports,
+      NanNew<v8::String>("MyObject").ToLocalChecked(), tpl->GetFunction());
 }
 
 NAN_METHOD(MyObject::New) {
-    NanScope();
+  NanScope();
 
-    if (args.IsConstructCall()) {
-        MyObject* obj = new MyObject();
-        obj->Wrap(args.This());
-        NanReturnValue(args.This());
-    }
-    else {
-        v8::Local<v8::Function> cons = NanNew<v8::Function>(constructor);
-        NanReturnValue(cons->NewInstance());
-    }
+  if (args.IsConstructCall()) {
+    MyObject* obj = new MyObject();
+    obj->Wrap(args.This());
+    NanReturnValue(args.This());
+  } else {
+    v8::Local<v8::Function> cons = NanNew<v8::Function>(constructor);
+    NanReturnValue(cons->NewInstance());
+  }
 }
 
 NAN_METHOD(MyObject::CallEmit) {
-    NanScope();
-    v8::Handle<v8::Value> argv[1] = {
-        NanNew("event"), // event name
-    };
+  NanScope();
+  v8::Handle<v8::Value> argv[1] = {
+    NanNew("event").ToLocalChecked(),  // event name
+  };
 
-    NanMakeCallback(args.This(), "emit", 1, argv);
-    NanReturnUndefined();
+  NanMakeCallback(args.This(), "emit", 1, argv);
+  NanReturnUndefined();
 }
 
 void Init(v8::Handle<v8::Object> exports) {
-    MyObject::Init(exports);
+  MyObject::Init(exports);
 }
 
 NODE_MODULE(makecallback, Init)

--- a/test/cpp/morenews.cpp
+++ b/test/cpp/morenews.cpp
@@ -26,19 +26,19 @@ NAN_METHOD(NewPositiveInteger) {
 NAN_METHOD(NewUtf8String) {
   NanScope();
   const char s[] = "strïng";
-  NanReturnValue(NanNew(s));
+  NanReturnValue(NanNew(s).ToLocalChecked());
 }
 
 NAN_METHOD(NewLatin1String) {
   NanScope();
   const uint8_t s[] = "str\xefng";
-  NanReturnValue(NanNew(s));
+  NanReturnValue(NanNew(s).ToLocalChecked());
 }
 
 NAN_METHOD(NewUcs2String) {
   NanScope();
   uint16_t s[] = {'s', 't', 'r', 0xef, 'n', 'g', '\0'};
-  NanReturnValue(NanNew(s));
+  NanReturnValue(NanNew(s).ToLocalChecked());
 }
 
 static const uint16_t ws[] = {'s', 't', 'r', 0xef, 'n', 'g', '\0'};
@@ -61,47 +61,47 @@ class ExtAsciiString : public NanExternalOneByteStringResource {
 
 NAN_METHOD(NewExternalStringResource) {
   NanScope();
-  v8::Local<v8::String> ext = NanNew(new ExtString());
+  v8::Local<v8::String> ext = NanNew(new ExtString()).ToLocalChecked();
   NanReturnValue(ext);
 }
 
 NAN_METHOD(NewExternalAsciiStringResource) {
   NanScope();
-  v8::Local<v8::String> ext = NanNew(new ExtAsciiString());
+  v8::Local<v8::String> ext = NanNew(new ExtAsciiString()).ToLocalChecked();
   NanReturnValue(ext);
 }
 
 void Init(v8::Handle<v8::Object> target) {
-  target->Set(
-      NanNew("newNumber")
+  NanSet(target
+    , NanNew("newNumber").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(NewNumber)->GetFunction()
   );
-  target->Set(
-      NanNew("newNegativeInteger")
+  NanSet(target
+    , NanNew("newNegativeInteger").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(NewNegativeInteger)->GetFunction()
   );
-  target->Set(
-      NanNew("newPositiveInteger")
+  NanSet(target
+    , NanNew("newPositiveInteger").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(NewPositiveInteger)->GetFunction()
   );
-  target->Set(
-      NanNew("newUtf8String")
+  NanSet(target
+    , NanNew("newUtf8String").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(NewUtf8String)->GetFunction()
   );
-  target->Set(
-      NanNew("newLatin1String")
+  NanSet(target
+    , NanNew("newLatin1String").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(NewLatin1String)->GetFunction()
   );
-  target->Set(
-      NanNew("newUcs2String")
+  NanSet(target
+    , NanNew("newUcs2String").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(NewUcs2String)->GetFunction()
   );
-  target->Set(
-      NanNew("newExternalStringResource")
+  NanSet(target
+    , NanNew("newExternalStringResource").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(NewExternalStringResource)->GetFunction()
   );
-  target->Set(
-      NanNew("newExternalAsciiStringResource")
+  NanSet(target
+    , NanNew("newExternalAsciiStringResource").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(NewExternalAsciiStringResource)
     ->GetFunction()
   );

--- a/test/cpp/multifile1.cpp
+++ b/test/cpp/multifile1.cpp
@@ -10,8 +10,8 @@
 #include "./multifile2.h"
 
 void Init (v8::Handle<v8::Object> target) {
-  target->Set(
-      NanNew<v8::String>("r")
+  NanSet(target
+    , NanNew<v8::String>("r").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(ReturnString)->GetFunction()
   );
 }

--- a/test/cpp/multifile2.cpp
+++ b/test/cpp/multifile2.cpp
@@ -10,6 +10,7 @@
 
 NAN_METHOD(ReturnString) {
   NanScope();
-  v8::Local<v8::String> s = NanNew<v8::String>(*NanUtf8String(args[0]));
+  v8::Local<v8::String> s =
+      NanNew<v8::String>(*NanUtf8String(args[0])).ToLocalChecked();
   NanReturnValue(s);
 }

--- a/test/cpp/nancallback.cpp
+++ b/test/cpp/nancallback.cpp
@@ -35,16 +35,16 @@ NAN_METHOD(CompareCallbacks) {
 }
 
 void Init (v8::Handle<v8::Object> target) {
-  target->Set(
-      NanNew<v8::String>("globalContext")
+  NanSet(target
+    , NanNew<v8::String>("globalContext").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(GlobalContext)->GetFunction()
   );
-  target->Set(
-      NanNew<v8::String>("specificContext")
+  NanSet(target
+    , NanNew<v8::String>("specificContext").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(SpecificContext)->GetFunction()
   );
-  target->Set(
-      NanNew<v8::String>("compareCallbacks")
+  NanSet(target
+    , NanNew<v8::String>("compareCallbacks").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(CompareCallbacks)->GetFunction()
   );
 }

--- a/test/cpp/nannew.cpp
+++ b/test/cpp/nannew.cpp
@@ -125,7 +125,8 @@ NAN_METHOD(testDate) {
 
   t.plan(1);
 
-  t.ok(_( assertType<Date>( NanNew<Date>(static_cast<double>(time(NULL))))));
+  t.ok(_( assertType<Date>(
+      NanNew<Date>(static_cast<double>(time(NULL))).ToLocalChecked())));
 
   return_NanUndefined();
 }
@@ -150,7 +151,7 @@ NAN_METHOD(testFunction) {
   t.plan(2);
 
   t.ok(_( assertType<Function>(NanNew<Function>(testFunction))));
-  v8::Local<String> data = NanNew("plonk");
+  v8::Local<String> data = NanNew("plonk").ToLocalChecked();
   t.ok(_( assertType<Function>(NanNew<Function>(testFunction, data))));
 
   return_NanUndefined();
@@ -165,7 +166,7 @@ NAN_METHOD(testFunctionTemplate) {
   t.ok(_( assertType<FunctionTemplate>( NanNew<FunctionTemplate>())));
   t.ok(_( assertType<FunctionTemplate>(
           NanNew<FunctionTemplate>(testFunctionTemplate))));
-  v8::Local<String> data = NanNew("plonk");
+  v8::Local<String> data = NanNew("plonk").ToLocalChecked();
   t.ok(_( assertType<FunctionTemplate>(
           NanNew<FunctionTemplate>( testFunctionTemplate, data))));
   v8::Local<Signature> signature = NanNew<Signature>();
@@ -219,7 +220,10 @@ NAN_METHOD(testNumberObject) {
   t.plan(2);
 
   t.ok(_( assertType<NumberObject>( NanNew<NumberObject>(M_PI))));
-  t.ok(_( fabs(NanNew<NumberObject>(M_PI)->NumberValue() - M_PI) < epsilon));
+  t.ok(_(
+      fabs(
+          NanNumberValue(NanNew<NumberObject>(M_PI)).FromJust() - M_PI
+      ) < epsilon));
 
   return_NanUndefined();
 }
@@ -252,20 +256,26 @@ NAN_METHOD(testScript) {
 
   t.plan(6);
 
-  ScriptOrigin origin(NanNew("foo"), NanNew(5));
+  ScriptOrigin origin(NanNew("foo").ToLocalChecked(), NanNew(5));
 
-  t.ok(_( assertType<Script>( NanNew<Script>(NanNew("2 + 3")))));
-  t.ok(_( assertType<Script>( NanNew<Script>(NanNew("2 + 3"), origin))));
+  t.ok(_( assertType<Script>(NanNew<Script>(
+      NanNew("2 + 3").ToLocalChecked()).ToLocalChecked())));
+  t.ok(_( assertType<Script>(NanNew<Script>(
+      NanNew("2 + 3").ToLocalChecked(), origin).ToLocalChecked())));
+  t.ok(_( assertType<NanUnboundScript>(NanNew<NanUnboundScript>(
+      NanNew("2 + 3").ToLocalChecked()).ToLocalChecked())));
   t.ok(_( assertType<NanUnboundScript>(
-      NanNew<NanUnboundScript>(NanNew("2 + 3")))));
-  t.ok(_( assertType<NanUnboundScript>(
-          NanNew<NanUnboundScript>(NanNew("2 + 3"), origin))));
+      NanNew<NanUnboundScript>(
+          NanNew("2 + 3").ToLocalChecked()
+        , origin).ToLocalChecked())));
 
   // for the fans of the bound script
-  t.ok(_( NanRunScript(
-      NanNew<NanBoundScript>(NanNew("2 + 3")))->Int32Value() == 5));
-  t.ok(_( NanRunScript(
-      NanNew<NanUnboundScript>(NanNew("2 + 3")))->Int32Value() == 5));
+  t.ok(_( NanInt32Value(NanRunScript(
+      NanNew<NanBoundScript>(NanNew("2 + 3").ToLocalChecked()
+    ).ToLocalChecked()).ToLocalChecked()).FromJust() == 5));
+  t.ok(_( NanInt32Value(NanRunScript(
+      NanNew<NanUnboundScript>(NanNew("2 + 3").ToLocalChecked()
+    ).ToLocalChecked()).ToLocalChecked()).FromJust() == 5));
 
   return_NanUndefined();
 }
@@ -293,30 +303,37 @@ NAN_METHOD(testString) {
 
   t.plan(14);
 
-  t.ok(_( stringMatches( NanNew<String>("Hello World"), "Hello World")));
-  t.ok(_( stringMatches( NanNew<String>("Hello World", 4), "Hell")));
-  t.ok(_( stringMatches( NanNew<String>(std::string("foo")), "foo")));
-  t.ok(_( assertType<String>( NanNew<String>("plonk."))));
+  t.ok(_( stringMatches(
+      NanNew<String>("Hello World").ToLocalChecked(), "Hello World")));
+  t.ok(_( stringMatches(
+      NanNew<String>("Hello World", 4).ToLocalChecked(), "Hell")));
+  t.ok(_( stringMatches(
+      NanNew<String>(std::string("foo")).ToLocalChecked(), "foo")));
+  t.ok(_( assertType<String>(
+      NanNew<String>("plonk.").ToLocalChecked())));
 
-  t.ok(_( stringMatches( NanNew<String>(), "")));
-  t.ok(_( assertType<String>( NanNew<String>())));
+  t.ok(_( stringMatches( NanNew<String>().ToLocalChecked(), "")));
+  t.ok(_( assertType<String>( NanNew<String>().ToLocalChecked())));
 
   // These should be deprecated
   const uint8_t *ustring = reinterpret_cast<const uint8_t *>("unsigned chars");
-  t.ok(_( stringMatches( NanNew<String>(ustring), "unsigned chars")));
-  t.ok(_( stringMatches( NanNew<String>(ustring, 8), "unsigned")));
+  t.ok(_( stringMatches(
+      NanNew<String>(ustring).ToLocalChecked(), "unsigned chars")));
+  t.ok(_( stringMatches(
+      NanNew<String>(ustring, 8).ToLocalChecked(), "unsigned")));
 
   // === Convenience
 
-  t.ok(_( stringMatches( NanNew("using namespace nan; // is poetry"),
-          "using namespace nan; // is poetry")));
-  t.ok(_( assertType<String>( NanNew("plonk."))));
+  t.ok(_( stringMatches(
+      NanNew("using namespace nan; // is poetry").ToLocalChecked()
+    , "using namespace nan; // is poetry")));
+  t.ok(_( assertType<String>( NanNew("plonk.").ToLocalChecked())));
 
-  t.ok(_( stringMatches( NanNew("Hello World", 4), "Hell")));
-  t.ok(_( assertType<String>( NanNew("plonk.", 4))));
+  t.ok(_( stringMatches( NanNew("Hello World", 4).ToLocalChecked(), "Hell")));
+  t.ok(_( assertType<String>( NanNew("plonk.", 4).ToLocalChecked())));
 
-  t.ok(_( stringMatches( NanNew(std::string("bar")), "bar")));
-  t.ok(_( assertType<String>( NanNew(std::string("plonk.")))));
+  t.ok(_( stringMatches( NanNew(std::string("bar")).ToLocalChecked(), "bar")));
+  t.ok(_( assertType<String>( NanNew(std::string("plonk.")).ToLocalChecked())));
 
   return_NanUndefined();
 }
@@ -333,10 +350,10 @@ NAN_METHOD(testStringObject) {
   t.plan(2);
 
   t.ok(_( stringMatches(
-          V(NanNew<StringObject>(NanNew<String>("plonk"))),
+          V(NanNew<StringObject>(NanNew<String>("plonk").ToLocalChecked())),
           "plonk")));
   t.ok(_( assertType<StringObject>(
-          NanNew<StringObject>(NanNew<String>("plonk")))));
+          NanNew<StringObject>(NanNew<String>("plonk").ToLocalChecked()))));
 
   return_NanUndefined();
 }
@@ -349,7 +366,8 @@ NAN_METHOD(testHandles) {
 
   t.plan(2);
 
-  t.ok(_( assertType<String>( NanNew( asHandle(NanNew("foo"))))));
+  t.ok(_( assertType<String>(
+      NanNew( asHandle(NanNew("foo").ToLocalChecked())))));
   t.ok(_( assertType<Uint32>( NanNew( asHandle(NanNew(5u))))));
 
   return_NanUndefined();
@@ -362,7 +380,7 @@ NAN_METHOD(testPersistents) {
   t.plan(1);
 
   Persistent<String> p;
-  NanAssignPersistent(p, NanNew("foo"));
+  NanAssignPersistent(p, NanNew("foo").ToLocalChecked());
   t.ok(_( assertType<String>( NanNew(p))));
   NanDisposePersistent(p);
 
@@ -428,32 +446,32 @@ NAN_METHOD(testRegression242) {
 
 NAN_METHOD(newIntegerWithValue) {
   NanScope();
-  return_NanValue(NanNew<Integer>(args[0]->Int32Value()));
+  return_NanValue(NanNew<Integer>(NanInt32Value(args[0]).FromJust()));
 }
 
 NAN_METHOD(newNumberWithValue) {
   NanScope();
-  return_NanValue(NanNew<Number>(args[0]->NumberValue()));
+  return_NanValue(NanNew<Number>(NanNumberValue(args[0]).FromJust()));
 }
 
 NAN_METHOD(newUint32WithValue) {
   NanScope();
-  return_NanValue(NanNew<Uint32>(args[0]->Uint32Value()));
+  return_NanValue(NanNew<Uint32>(NanUint32Value(args[0]).FromJust()));
 }
 
 NAN_METHOD(newStringFromChars) {
   NanScope();
-  return_NanValue(NanNew<String>("hello?"));
+  return_NanValue(NanNew<String>("hello?").ToLocalChecked());
 }
 
 NAN_METHOD(newStringFromCharsWithLength) {
   NanScope();
-  return_NanValue(NanNew<String>("hello?", 4));
+  return_NanValue(NanNew<String>("hello?", 4).ToLocalChecked());
 }
 
 NAN_METHOD(newStringFromStdString) {
   NanScope();
-  return_NanValue(NanNew<String>(std::string("hello!")));
+  return_NanValue(NanNew<String>(std::string("hello!")).ToLocalChecked());
 }
 
 NAN_METHOD(newExternal) {

--- a/test/cpp/news.cpp
+++ b/test/cpp/news.cpp
@@ -60,35 +60,36 @@ NAN_METHOD(NewUint32FromNegative) {
 NAN_METHOD(NewUtf8String) {
   NanScope();
   const char s[] = "strïng";
-  NanReturnValue(NanNew<v8::String>(s));
+  NanReturnValue(NanNew<v8::String>(s).ToLocalChecked());
 }
 
 NAN_METHOD(NewLatin1String) {
   NanScope();
   const uint8_t s[] = "str\xefng";
-  NanReturnValue(NanNew<v8::String>(s));
+  NanReturnValue(NanNew<v8::String>(s).ToLocalChecked());
 }
 
 NAN_METHOD(NewUcs2String) {
   NanScope();
   const uint16_t s[] = {'s', 't', 'r', 0xef, 'n', 'g', '\0'};
-  NanReturnValue(NanNew(s));
+  NanReturnValue(NanNew(s).ToLocalChecked());
 }
 
 NAN_METHOD(NewStdString) {
   NanScope();
   const std::string s = "strïng";
-  NanReturnValue(NanNew<v8::String>(s));
+  NanReturnValue(NanNew<v8::String>(s).ToLocalChecked());
 }
 
 NAN_METHOD(NewRegExp) {
   NanScope();
-  NanReturnValue(NanNew<v8::RegExp>(NanNew("foo"), v8::RegExp::kNone));
+  NanReturnValue(NanNew<v8::RegExp>(
+      NanNew("foo").ToLocalChecked(), v8::RegExp::kNone).ToLocalChecked());
 }
 
 NAN_METHOD(NewStringObject) {
   NanScope();
-  NanReturnValue(NanNew<v8::StringObject>(NanNew<v8::String>("foo")));
+  NanReturnValue(NanNew<v8::StringObject>(NanNew("foo").ToLocalChecked()));
 }
 
 NAN_METHOD(NewNumberObject) {
@@ -105,7 +106,7 @@ NAN_METHOD(NewExternal) {
   NanScope();
   v8::Local<v8::External> ext = NanNew<v8::External>(&magic);
   assert(*static_cast<int *>(ext->Value()) == 1337);
-  NanReturnValue(NanNew<v8::String>("passed"));
+  NanReturnValue(NanNew<v8::String>("passed").ToLocalChecked());
 }
 
 NAN_METHOD(NewSignature) {
@@ -115,39 +116,48 @@ NAN_METHOD(NewSignature) {
   v8::Local<v8::Signature> sig = NanNew<v8::Signature>(tmpl);
   tmpl = NanNew<v8::FunctionTemplate>(
       NewSignature, v8::Handle<v8::Value>(), sig);
-  NanReturnValue(NanNew<v8::String>("string"));
+  NanReturnValue(NanNew<v8::String>("string").ToLocalChecked());
 }
 
 NAN_METHOD(NewScript) {
   NanScope();
-  v8::Local<NanUnboundScript> script = NanNew<NanUnboundScript>(NanNew("2+4"));
-  NanReturnValue(NanRunScript(script)->ToInt32());
+  v8::Local<NanUnboundScript> script =
+      NanNew<NanUnboundScript>(NanNew("2+4").ToLocalChecked()).ToLocalChecked();
+  NanReturnValue(
+      NanToInt32(NanRunScript(script).ToLocalChecked()).ToLocalChecked());
 }
 
 NAN_METHOD(NewScript2) {
   NanScope();
-  v8::ScriptOrigin origin(NanNew<v8::String>("x"));
+  v8::ScriptOrigin origin(NanNew<v8::String>("x").ToLocalChecked());
   v8::Local<NanUnboundScript> script =
-      NanNew<NanUnboundScript>(NanNew("2+4"), origin);
-  NanReturnValue(NanRunScript(script)->ToInt32());
+      NanNew<NanUnboundScript>(
+          NanNew("2+4").ToLocalChecked()
+        , origin).ToLocalChecked();
+  NanReturnValue(
+      NanToInt32(NanRunScript(script).ToLocalChecked()).ToLocalChecked());
 }
 
 NAN_METHOD(CompileScript) {
   NanScope();
-  v8::Local<NanBoundScript> script = NanCompileScript(NanNew("2+4"));
-  NanReturnValue(NanRunScript(script)->ToInt32());
+  v8::Local<NanBoundScript> script =
+      NanCompileScript(NanNew("2+4").ToLocalChecked()).ToLocalChecked();
+  NanReturnValue(
+      NanToInt32(NanRunScript(script).ToLocalChecked()).ToLocalChecked());
 }
 
 NAN_METHOD(CompileScript2) {
   NanScope();
-  v8::ScriptOrigin origin(NanNew<v8::String>("x"));
-  v8::Local<NanBoundScript> script = NanCompileScript(NanNew("2+4"), origin);
-  NanReturnValue(NanRunScript(script)->ToInt32());
+  v8::ScriptOrigin origin(NanNew<v8::String>("x").ToLocalChecked());
+  v8::Local<NanBoundScript> script =
+      NanCompileScript(NanNew("2+4").ToLocalChecked(), origin).ToLocalChecked();
+  NanReturnValue(
+      NanToInt32(NanRunScript(script).ToLocalChecked()).ToLocalChecked());
 }
 
 NAN_METHOD(NewDate) {
   NanScope();
-  NanReturnValue(NanNew<v8::Date>(1337));
+  NanReturnValue(NanNew<v8::Date>(1337).ToLocalChecked());
 }
 
 NAN_METHOD(NewArray) {
@@ -173,108 +183,108 @@ NAN_METHOD(NewBoolean2) {
 }
 
 void Init(v8::Handle<v8::Object> target) {
-  target->Set(
-      NanNew<v8::String>("newNumber")
+  NanSet(target
+    , NanNew<v8::String>("newNumber").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(NewNumber)->GetFunction()
   );
-  target->Set(
-      NanNew<v8::String>("newNegativeInteger")
+  NanSet(target
+    , NanNew<v8::String>("newNegativeInteger").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(NewNegativeInteger)->GetFunction()
   );
-  target->Set(
-      NanNew<v8::String>("newPositiveInteger")
+  NanSet(target
+    , NanNew<v8::String>("newPositiveInteger").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(NewPositiveInteger)->GetFunction()
   );
-  target->Set(
-      NanNew<v8::String>("newUnsignedInteger")
+  NanSet(target
+    , NanNew<v8::String>("newUnsignedInteger").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(NewUnsignedInteger)->GetFunction()
   );
-  target->Set(
-      NanNew<v8::String>("newInt32FromPositive")
+  NanSet(target
+    , NanNew<v8::String>("newInt32FromPositive").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(NewInt32FromPositive)->GetFunction()
   );
-  target->Set(
-      NanNew<v8::String>("newInt32FromNegative")
+  NanSet(target
+    , NanNew<v8::String>("newInt32FromNegative").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(NewInt32FromNegative)->GetFunction()
   );
-  target->Set(
-      NanNew<v8::String>("newUint32FromPositive")
+  NanSet(target
+    , NanNew<v8::String>("newUint32FromPositive").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(NewUint32FromPositive)->GetFunction()
   );
-  target->Set(
-      NanNew<v8::String>("newUint32FromNegative")
+  NanSet(target
+    , NanNew<v8::String>("newUint32FromNegative").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(NewUint32FromNegative)->GetFunction()
   );
-  target->Set(
-      NanNew<v8::String>("newUtf8String")
+  NanSet(target
+    , NanNew<v8::String>("newUtf8String").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(NewUtf8String)->GetFunction()
   );
-  target->Set(
-      NanNew<v8::String>("newLatin1String")
+  NanSet(target
+    , NanNew<v8::String>("newLatin1String").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(NewLatin1String)->GetFunction()
   );
-  target->Set(
-      NanNew<v8::String>("newUcs2String")
+  NanSet(target
+    , NanNew<v8::String>("newUcs2String").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(NewUcs2String)->GetFunction()
   );
-  target->Set(
-      NanNew<v8::String>("newStdString")
+  NanSet(target
+    , NanNew<v8::String>("newStdString").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(NewStdString)->GetFunction()
   );
-  target->Set(
-      NanNew<v8::String>("newRegExp")
+  NanSet(target
+    , NanNew<v8::String>("newRegExp").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(NewRegExp)->GetFunction()
   );
-  target->Set(
-      NanNew<v8::String>("newStringObject")
+  NanSet(target
+    , NanNew<v8::String>("newStringObject").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(NewStringObject)->GetFunction()
   );
-  target->Set(
-      NanNew<v8::String>("newNumberObject")
+  NanSet(target
+    , NanNew<v8::String>("newNumberObject").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(NewNumberObject)->GetFunction()
   );
-  target->Set(
-      NanNew<v8::String>("newBooleanObject")
+  NanSet(target
+    , NanNew<v8::String>("newBooleanObject").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(NewBooleanObject)->GetFunction()
   );
-  target->Set(
-      NanNew<v8::String>("newExternal")
+  NanSet(target
+    , NanNew<v8::String>("newExternal").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(NewExternal)->GetFunction()
   );
-  target->Set(
-      NanNew<v8::String>("newSignature")
+  NanSet(target
+    , NanNew<v8::String>("newSignature").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(NewSignature)->GetFunction()
   );
-  target->Set(
-      NanNew<v8::String>("newScript")
+  NanSet(target
+    , NanNew<v8::String>("newScript").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(NewScript)->GetFunction()
   );
-  target->Set(
-      NanNew<v8::String>("newScript2")
+  NanSet(target
+    , NanNew<v8::String>("newScript2").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(NewScript2)->GetFunction()
   );
-  target->Set(
-      NanNew<v8::String>("compileScript")
+  NanSet(target
+    , NanNew<v8::String>("compileScript").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(CompileScript)->GetFunction()
   );
-  target->Set(
-      NanNew<v8::String>("compileScript2")
+  NanSet(target
+    , NanNew<v8::String>("compileScript2").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(CompileScript2)->GetFunction()
   );
-  target->Set(
-      NanNew<v8::String>("newDate")
+  NanSet(target
+    , NanNew<v8::String>("newDate").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(NewDate)->GetFunction()
   );
-  target->Set(
-      NanNew<v8::String>("newArray")
+  NanSet(target
+    , NanNew<v8::String>("newArray").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(NewArray)->GetFunction()
   );
-  target->Set(
-      NanNew<v8::String>("newBoolean")
+  NanSet(target
+    , NanNew<v8::String>("newBoolean").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(NewBoolean)->GetFunction()
   );
-  target->Set(
-      NanNew<v8::String>("newBoolean2")
+  NanSet(target
+    , NanNew<v8::String>("newBoolean2").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(NewBoolean2)->GetFunction()
   );
 }

--- a/test/cpp/optionvalues.cpp
+++ b/test/cpp/optionvalues.cpp
@@ -14,28 +14,47 @@ NAN_METHOD(OptionValues) {
   v8::Local<v8::Object> inobj = args[0].As<v8::Object>();
   v8::Local<v8::Object> outobj = NanNew<v8::Object>();
 
-  bool boolt = NanBooleanOptionValue(inobj, NanNew("true"));
-  bool boolf = NanBooleanOptionValue(inobj, NanNew("false"));
-  bool booldt = NanBooleanOptionValue(inobj, NanNew("dt"), true);
-  bool booldf = NanBooleanOptionValue(inobj, NanNew("df"), false);
-  uint32_t uint32i = NanUInt32OptionValue(inobj, NanNew("i"), 0);
-  uint32_t uint32f = NanUInt32OptionValue(inobj, NanNew("f"), 0);
-  uint32_t uint32di = NanUInt32OptionValue(inobj, NanNew("di"), 111);
+  bool boolt = NanBooleanOptionValue(
+      inobj
+    , NanNew("true").ToLocalChecked());
+  bool boolf = NanBooleanOptionValue(
+      inobj
+    , NanNew("false").ToLocalChecked());
+  bool booldt = NanBooleanOptionValue(
+      inobj
+    , NanNew("dt").ToLocalChecked()
+    , true);
+  bool booldf = NanBooleanOptionValue(
+      inobj
+    , NanNew("df").ToLocalChecked()
+    , false);
+  uint32_t uint32i = NanUInt32OptionValue(
+      inobj
+    , NanNew("i").ToLocalChecked()
+    , 0);
+  uint32_t uint32f = NanUInt32OptionValue(
+      inobj
+    , NanNew("f").ToLocalChecked()
+    , 0);
+  uint32_t uint32di = NanUInt32OptionValue(
+      inobj
+    , NanNew("di").ToLocalChecked()
+    , 111);
 
-  outobj->Set(NanNew("true"), NanNew(boolt));
-  outobj->Set(NanNew("false"), NanNew(boolf));
-  outobj->Set(NanNew("dt"), NanNew(booldt));
-  outobj->Set(NanNew("df"), NanNew(booldf));
-  outobj->Set(NanNew("i"), NanNew(uint32i));
-  outobj->Set(NanNew("f"), NanNew(uint32f));
-  outobj->Set(NanNew("di"), NanNew(uint32di));
+  NanSet(outobj, NanNew("true").ToLocalChecked(), NanNew(boolt));
+  NanSet(outobj, NanNew("false").ToLocalChecked(), NanNew(boolf));
+  NanSet(outobj, NanNew("dt").ToLocalChecked(), NanNew(booldt));
+  NanSet(outobj, NanNew("df").ToLocalChecked(), NanNew(booldf));
+  NanSet(outobj, NanNew("i").ToLocalChecked(), NanNew(uint32i));
+  NanSet(outobj, NanNew("f").ToLocalChecked(), NanNew(uint32f));
+  NanSet(outobj, NanNew("di").ToLocalChecked(), NanNew(uint32di));
 
   NanReturnValue(outobj);
 }
 
 void Init (v8::Handle<v8::Object> target) {
-  target->Set(
-      NanNew("o")
+  NanSet(target
+    , NanNew("o").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(OptionValues)->GetFunction()
   );
 }

--- a/test/cpp/persistent.cpp
+++ b/test/cpp/persistent.cpp
@@ -58,24 +58,24 @@ NAN_METHOD(PersistentToPersistent) {
 }
 
 void Init (v8::Handle<v8::Object> target) {
-  target->Set(
-      NanNew<v8::String>("save1")
+  NanSet(target
+    , NanNew<v8::String>("save1").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(Save1)->GetFunction()
   );
-  target->Set(
-      NanNew<v8::String>("get1")
+  NanSet(target
+    , NanNew<v8::String>("get1").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(Get1)->GetFunction()
   );
-  target->Set(
-      NanNew<v8::String>("dispose1")
+  NanSet(target
+    , NanNew<v8::String>("dispose1").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(Dispose1)->GetFunction()
   );
-  target->Set(
-      NanNew<v8::String>("toPersistentAndBackAgain")
+  NanSet(target
+    , NanNew<v8::String>("toPersistentAndBackAgain").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(ToPersistentAndBackAgain)->GetFunction()
   );
-  target->Set(
-      NanNew<v8::String>("persistentToPersistent")
+  NanSet(target
+    , NanNew<v8::String>("persistentToPersistent").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(PersistentToPersistent)->GetFunction()
   );
 }

--- a/test/cpp/returnemptystring.cpp
+++ b/test/cpp/returnemptystring.cpp
@@ -14,8 +14,8 @@ NAN_METHOD(ReturnEmptyString) {
 }
 
 void Init (v8::Handle<v8::Object> target) {
-  target->Set(
-      NanNew<v8::String>("r")
+  NanSet(target
+    , NanNew<v8::String>("r").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(ReturnEmptyString)->GetFunction()
   );
 }

--- a/test/cpp/returnnull.cpp
+++ b/test/cpp/returnnull.cpp
@@ -14,8 +14,8 @@ NAN_METHOD(ReturnNull) {
 }
 
 void Init (v8::Handle<v8::Object> target) {
-  target->Set(
-      NanNew<v8::String>("r")
+  NanSet(target
+    , NanNew<v8::String>("r").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(ReturnNull)->GetFunction()
   );
 }

--- a/test/cpp/returnundefined.cpp
+++ b/test/cpp/returnundefined.cpp
@@ -14,8 +14,8 @@ NAN_METHOD(ReturnUndefined) {
 }
 
 void Init (v8::Handle<v8::Object> target) {
-  target->Set(
-      NanNew<v8::String>("r")
+  NanSet(target
+    , NanNew<v8::String>("r").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(ReturnUndefined)->GetFunction()
   );
 }

--- a/test/cpp/returnvalue.cpp
+++ b/test/cpp/returnvalue.cpp
@@ -13,7 +13,7 @@ NAN_METHOD(ReturnValue) {
   if (args.Length() == 1) {
     NanReturnValue(args[0]);
   } else {
-    NanReturnValue(NanNew<v8::String>("default"));
+    NanReturnValue(NanNew<v8::String>("default").ToLocalChecked());
   }
 }
 
@@ -28,16 +28,16 @@ NAN_METHOD(ReturnString) {
 }
 
 void Init (v8::Handle<v8::Object> target) {
-  target->Set(
-      NanNew<v8::String>("r")
+  NanSet(target
+    , NanNew<v8::String>("r").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(ReturnValue)->GetFunction()
   );
-  target->Set(
-      NanNew<v8::String>("p")
+  NanSet(target
+    , NanNew<v8::String>("p").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(ReturnPrimitive)->GetFunction()
   );
-  target->Set(
-      NanNew<v8::String>("s")
+  NanSet(target
+    , NanNew<v8::String>("s").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(ReturnString)->GetFunction()
   );
 }

--- a/test/cpp/settemplate.cpp
+++ b/test/cpp/settemplate.cpp
@@ -9,15 +9,15 @@
 #include <nan.h>
 
 class MyObject : public node::ObjectWrap {
-public:
-	static void Init(v8::Handle<v8::Object> exports);
+ public:
+  static void Init(v8::Handle<v8::Object> exports);
 
-private:
-	MyObject();
-	~MyObject();
+ private:
+  MyObject();
+  ~MyObject();
 
-	static NAN_METHOD(New);
-	static v8::Persistent<v8::Function> constructor;
+  static NAN_METHOD(New);
+  static v8::Persistent<v8::Function> constructor;
 };
 
 v8::Persistent<v8::Function> MyObject::constructor;
@@ -29,43 +29,68 @@ MyObject::~MyObject() {
 }
 
 void MyObject::Init(v8::Handle<v8::Object> exports) {
-	NanScope();
+  NanScope();
 
-	// Prepare constructor template
-	v8::Local<v8::FunctionTemplate> tpl = NanNew<v8::FunctionTemplate>(New);
-	tpl->SetClassName(NanNew<v8::String>("MyObject"));
-	tpl->InstanceTemplate()->SetInternalFieldCount(1);
+  // Prepare constructor template
+  v8::Local<v8::FunctionTemplate> tpl = NanNew<v8::FunctionTemplate>(New);
+  tpl->SetClassName(NanNew<v8::String>("MyObject").ToLocalChecked());
+  tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
-	// Prototype
-	NanSetPrototypeTemplate(tpl, "prototypeProp", NanNew<v8::String>("a prototype property"));
-	// Instance
-	NanSetInstanceTemplate(tpl, "instanceProp", NanNew<v8::String>("an instance property"));
-	// PropertyAttributes
-	NanSetInstanceTemplate(tpl, NanNew<v8::String>("none"), NanNew<v8::String>("none"), v8::None);
-	NanSetInstanceTemplate(tpl, NanNew<v8::String>("readOnly"), NanNew<v8::String>("readOnly"), v8::ReadOnly);
-	NanSetInstanceTemplate(tpl, NanNew<v8::String>("dontEnum"), NanNew<v8::String>("dontEnum"), v8::DontEnum);
-	NanSetInstanceTemplate(tpl, NanNew<v8::String>("dontDelete"), NanNew<v8::String>("dontDelete"), v8::DontDelete);
+  // Prototype
+  NanSetPrototypeTemplate(
+    tpl
+  , "prototypeProp"
+  , NanNew<v8::String>("a prototype property").ToLocalChecked());
 
-	NanAssignPersistent<v8::Function>(constructor, tpl->GetFunction());
-	exports->Set(NanNew<v8::String>("MyObject"), tpl->GetFunction());
+  // Instance
+  NanSetInstanceTemplate(
+    tpl
+  , "instanceProp"
+  , NanNew<v8::String>("an instance property").ToLocalChecked());
+
+  // PropertyAttributes
+  NanSetInstanceTemplate(
+    tpl
+  , NanNew<v8::String>("none").ToLocalChecked()
+  , NanNew<v8::String>("none").ToLocalChecked()
+  , v8::None);
+  NanSetInstanceTemplate(
+    tpl
+  , NanNew<v8::String>("readOnly").ToLocalChecked()
+  , NanNew<v8::String>("readOnly").ToLocalChecked()
+  , v8::ReadOnly);
+  NanSetInstanceTemplate(
+    tpl
+  , NanNew<v8::String>("dontEnum").ToLocalChecked()
+  , NanNew<v8::String>("dontEnum").ToLocalChecked()
+  , v8::DontEnum);
+  NanSetInstanceTemplate(
+    tpl
+  , NanNew<v8::String>("dontDelete").ToLocalChecked()
+  , NanNew<v8::String>("dontDelete").ToLocalChecked()
+  , v8::DontDelete);
+
+  NanAssignPersistent<v8::Function>(constructor, tpl->GetFunction());
+  NanSet(exports
+  , NanNew<v8::String>("MyObject").ToLocalChecked()
+  , tpl->GetFunction());
 }
 
 NAN_METHOD(MyObject::New) {
-	NanScope();
+  NanScope();
 
-	if (args.IsConstructCall()) {
-		MyObject* obj = new MyObject();
-		obj->Wrap(args.This());
-		NanReturnValue(args.This());
-	}
-	else {
-		v8::Local<v8::Function> cons = NanNew<v8::Function>(constructor);
-		NanReturnValue(cons->NewInstance());
-	}
+  if (args.IsConstructCall()) {
+    MyObject* obj = new MyObject();
+    obj->Wrap(args.This());
+    NanReturnValue(args.This());
+  } else {
+    v8::Local<v8::Function> cons = NanNew<v8::Function>(constructor);
+    NanReturnValue(cons->NewInstance());
+  }
 }
 
 void Init(v8::Handle<v8::Object> exports) {
-	MyObject::Init(exports);
+  MyObject::Init(exports);
 }
 
 NODE_MODULE(settemplate, Init)

--- a/test/cpp/settergetter.cpp
+++ b/test/cpp/settergetter.cpp
@@ -44,20 +44,23 @@ void SetterGetter::Init(v8::Handle<v8::Object> target) {
   v8::Local<v8::FunctionTemplate> tpl =
     NanNew<v8::FunctionTemplate>(SetterGetter::New);
   NanAssignPersistent(settergetter_constructor, tpl);
-  tpl->SetClassName(NanNew<v8::String>("SetterGetter"));
+  tpl->SetClassName(NanNew<v8::String>("SetterGetter").ToLocalChecked());
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
   NODE_SET_PROTOTYPE_METHOD(tpl, "log", SetterGetter::Log);
   v8::Local<v8::ObjectTemplate> proto = tpl->PrototypeTemplate();
-  proto->SetAccessor(NanNew<v8::String>("prop1"), SetterGetter::GetProp1);
   proto->SetAccessor(
-    NanNew<v8::String>("prop2")
+    NanNew<v8::String>("prop1").ToLocalChecked()
+  , SetterGetter::GetProp1
+  );
+  proto->SetAccessor(
+    NanNew<v8::String>("prop2").ToLocalChecked()
   , SetterGetter::GetProp2
   , SetterGetter::SetProp2
   );
 
   v8::Local<v8::Function> createnew =
     NanNew<v8::FunctionTemplate>(CreateNew)->GetFunction();
-  target->Set(NanNew<v8::String>("create"), createnew);
+  NanSet(target, NanNew<v8::String>("create").ToLocalChecked(), createnew);
 }
 
 v8::Handle<v8::Value> SetterGetter::NewInstance () {
@@ -103,7 +106,7 @@ NAN_GETTER(SetterGetter::GetProp1) {
     , ")\n"
     , sizeof (settergetter->log) - 1 - strlen(settergetter->log));
 
-  NanReturnValue(NanNew(settergetter->prop1));
+  NanReturnValue(NanNew(settergetter->prop1).ToLocalChecked());
 }
 
 NAN_GETTER(SetterGetter::GetProp2) {
@@ -127,7 +130,7 @@ NAN_GETTER(SetterGetter::GetProp2) {
     , ")\n"
     , sizeof (settergetter->log) - 1 - strlen(settergetter->log));
 
-  NanReturnValue(NanNew(settergetter->prop2));
+  NanReturnValue(NanNew(settergetter->prop2).ToLocalChecked());
 }
 
 NAN_SETTER(SetterGetter::SetProp2) {
@@ -163,7 +166,7 @@ NAN_METHOD(SetterGetter::Log) {
   SetterGetter* settergetter =
     node::ObjectWrap::Unwrap<SetterGetter>(args.This());
 
-  NanReturnValue(NanNew(settergetter->log));
+  NanReturnValue(NanNew(settergetter->log).ToLocalChecked());
 }
 
 NODE_MODULE(settergetter, SetterGetter::Init)

--- a/test/cpp/strings.cpp
+++ b/test/cpp/strings.cpp
@@ -10,23 +10,23 @@
 
 NAN_METHOD(ReturnAsciiString) {
   NanScope();
-  NanReturnValue(NanNew(*NanAsciiString(args[0])));
+  NanReturnValue(NanNew(*NanAsciiString(args[0])).ToLocalChecked());
 }
 
 NAN_METHOD(ReturnUtf8String) {
   NanScope();
-  NanReturnValue(NanNew(*NanUtf8String(args[0])));
+  NanReturnValue(NanNew(*NanUtf8String(args[0])).ToLocalChecked());
 }
 
 NAN_METHOD(ReturnUcs2String) {
   NanScope();
-  NanReturnValue(NanNew(*NanUcs2String(args[0])));
+  NanReturnValue(NanNew(*NanUcs2String(args[0])).ToLocalChecked());
 }
 
 NAN_METHOD(HeapString) {
   NanScope();
   NanUcs2String *s = new NanUcs2String(args[0]);
-  v8::Local<v8::String> res = NanNew(**s);
+  v8::Local<v8::String> res = NanNew(**s).ToLocalChecked();
   delete s;
   NanReturnValue(res);
 }
@@ -59,8 +59,8 @@ void Init (v8::Handle<v8::Object> target) {
   , returnAsciiString
   );
 
-  target->Set(
-      NanNew("returnAsciiString")
+  NanSet(target
+    , NanNew("returnAsciiString").ToLocalChecked()
     , returnAsciiString->GetFunction()
   );
 
@@ -72,8 +72,8 @@ void Init (v8::Handle<v8::Object> target) {
   , returnUtf8String
   );
 
-  target->Set(
-      NanNew("returnUtf8String")
+  NanSet(target
+    , NanNew("returnUtf8String").ToLocalChecked()
     , returnUtf8String->GetFunction()
   );
 
@@ -85,8 +85,8 @@ void Init (v8::Handle<v8::Object> target) {
   , returnUcs2String
   );
 
-  target->Set(
-      NanNew("returnUcs2String")
+  NanSet(target
+    , NanNew("returnUcs2String").ToLocalChecked()
     , returnUcs2String->GetFunction()
   );
 
@@ -98,8 +98,8 @@ void Init (v8::Handle<v8::Object> target) {
   , heapString
   );
 
-  target->Set(
-      NanNew("heapString")
+  NanSet(target
+    , NanNew("heapString").ToLocalChecked()
     , heapString->GetFunction()
   );
 
@@ -111,8 +111,8 @@ void Init (v8::Handle<v8::Object> target) {
   , encodeHex
   );
 
-  target->Set(
-      NanNew("encodeHex")
+  NanSet(target
+    , NanNew("encodeHex").ToLocalChecked()
     , encodeHex->GetFunction()
   );
 
@@ -124,8 +124,8 @@ void Init (v8::Handle<v8::Object> target) {
   , encodeUCS2
   );
 
-  target->Set(
-      NanNew("encodeUCS2")
+  NanSet(target
+    , NanNew("encodeUCS2").ToLocalChecked()
     , encodeUCS2->GetFunction()
   );
 }

--- a/test/cpp/symbols.cpp
+++ b/test/cpp/symbols.cpp
@@ -9,7 +9,10 @@
 #include <nan.h>
 
 void Init (v8::Handle<v8::Object> target) {
-  target->Set(NanNew<v8::String>("key"), NanNew<v8::String>("a property"));
+  NanSet(target
+    , NanNew<v8::String>("key").ToLocalChecked()
+    , NanNew<v8::String>("a property").ToLocalChecked()
+  );
 }
 
 NODE_MODULE(symbols, Init)

--- a/test/cpp/threadlocal.cpp
+++ b/test/cpp/threadlocal.cpp
@@ -13,8 +13,8 @@
 // Based on test-thread.c from libuv.
 
 class TlsTest : public NanAsyncWorker {
-public:
-  TlsTest(NanTap *t) : NanAsyncWorker(NULL), t(t), i(0) {
+ public:
+  explicit TlsTest(NanTap *t) : NanAsyncWorker(NULL), t(t), i(0) {
     NanScope();
     t->plan(7);
     t->ok(_(0 == nauv_key_create(&tls_key)));
@@ -37,7 +37,8 @@ public:
     t->ok(_(NULL == ErrorMessage()));
     delete t;
   }
-private:
+
+ private:
   nauv_key_t tls_key;
 
   NanTap *t;
@@ -59,8 +60,8 @@ NAN_METHOD(thread_local_storage) {
 }
 
 void Init(v8::Handle<v8::Object> exports) {
-  exports->Set(
-      NanNew<v8::String>("thread_local_storage")
+  NanSet(exports
+    , NanNew<v8::String>("thread_local_storage").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(thread_local_storage)->GetFunction()
   );
 }

--- a/test/cpp/weak.cpp
+++ b/test/cpp/weak.cpp
@@ -19,7 +19,7 @@ NAN_WEAK_CALLBACK(weakCallback) {
 }
 
 v8::Handle<v8::String> wrap(v8::Local<v8::Function> func) {
-  v8::Local<v8::String> lstring = NanNew<v8::String>("result");
+  v8::Local<v8::String> lstring = NanNew<v8::String>("result").ToLocalChecked();
   int *parameter = new int(0);
   NanMakeWeakPersistent(func, parameter, &weakCallback);
   return lstring;
@@ -31,8 +31,8 @@ NAN_METHOD(Hustle) {
 }
 
 void Init (v8::Handle<v8::Object> target) {
-  target->Set(
-      NanNew<v8::String>("hustle")
+  NanSet(target
+    , NanNew<v8::String>("hustle").ToLocalChecked()
     , NanNew<v8::FunctionTemplate>(Hustle)->GetFunction()
   );
 }

--- a/test/js/converters-test.js
+++ b/test/js/converters-test.js
@@ -1,0 +1,43 @@
+/*********************************************************************
+ * NAN - Native Abstractions for Node.js
+ *
+ * Copyright (c) 2015 NAN contributors
+ *
+ * MIT License <https://github.com/rvagg/nan/blob/master/LICENSE.md>
+ ********************************************************************/
+
+const test     = require('tap').test
+    , testRoot = require('path').resolve(__dirname, '..')
+    , bindings = require('bindings')({ module_root: testRoot, bindings: 'converters' });
+
+test('converters', function (t) {
+  t.plan(26);
+
+  var converters = bindings;
+  t.type(converters.toBoolean, 'function');
+  t.type(converters.toNumber, 'function');
+  t.type(converters.toString, 'function');
+  t.type(converters.toDetailString, 'function');
+  t.type(converters.toObject, 'function');
+  t.type(converters.toInteger, 'function');
+  t.type(converters.toUint32, 'function');
+  t.type(converters.toInt32, 'function');
+  t.type(converters.booleanValue, 'function');
+  t.type(converters.numberValue, 'function');
+  t.type(converters.integerValue, 'function');
+  t.type(converters.uint32Value, 'function');
+  t.type(converters.int32Value, 'function');
+  t.equal(converters.toBoolean(true), true);
+  t.equal(converters.toNumber(15.3), 15.3);
+  t.equal(converters.toString('sol'), 'sol');
+  t.equal(converters.toDetailString('sol'), 'sol');
+  t.strictDeepEqual(converters.toObject({prop : 'x'}), {prop : 'x'});
+  t.equal(converters.toInteger(12), 12);
+  t.equal(converters.toUint32(12), 12);
+  t.equal(converters.toInt32(-12), -12);
+  t.equal(converters.booleanValue(true), true);
+  t.equal(converters.numberValue(15.3), 15.3);
+  t.equal(converters.integerValue(12), 12);
+  t.equal(converters.uint32Value(12), 12);
+  t.equal(converters.int32Value(-12), -12);
+});


### PR DESCRIPTION
This is the alternative solution to #289.
Currently forces the empty `String` constructor to return `NanMaybeLocal<String>`.

Now `NanNew<T>` will return a `NanMaybeLocal<T>` for some `T` (`NanBoundScript`, `NanUnboundScript`, `Date`, `RegExp` and `String`). For the convenience overload `NanNew(...)`, this thus only applies to the `String` types. This seems a little clumsy. Should the convenience method do `NanMaybeLocal::ToLocalChecked()`?