### PR TITLE
NanObjectWrapHandle should take a pointer

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,7 @@ LINT_SOURCES = \
 	test/cpp/nancallback.cpp \
 	test/cpp/nannew.cpp \
         test/cpp/news.cpp \
+	test/cpp/objectwraphandle.cpp \
 	test/cpp/optionvalues.cpp \
 	test/cpp/persistent.cpp \
 	test/cpp/returnemptystring.cpp \

--- a/nan.h
+++ b/nan.h
@@ -404,8 +404,8 @@ NAN_INLINE v8::Local<v8::Value> _NanEnsureLocal(T val) {
 # define NanReturnNull() return args.GetReturnValue().SetNull()
 # define NanReturnEmptyString() return args.GetReturnValue().SetEmptyString()
 
-  NAN_INLINE v8::Local<v8::Object> NanObjectWrapHandle(const node::ObjectWrap &obj) {
-    return const_cast<node::ObjectWrap &>(obj).handle();
+  NAN_INLINE v8::Local<v8::Object> NanObjectWrapHandle(const node::ObjectWrap *obj) {
+    return const_cast<node::ObjectWrap*>(obj)->handle();
   }
 
   NAN_INLINE v8::Local<v8::Primitive> NanUndefined() {
@@ -942,8 +942,8 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
 # define NanReturnNull() return v8::Null()
 # define NanReturnEmptyString() return v8::String::Empty()
 
-  NAN_INLINE v8::Local<v8::Object> NanObjectWrapHandle(const node::ObjectWrap &obj) {
-    return v8::Local<v8::Object>::New(obj.handle_);
+  NAN_INLINE v8::Local<v8::Object> NanObjectWrapHandle(const node::ObjectWrap *obj) {
+    return v8::Local<v8::Object>::New(obj->handle_);
   }
 
   NAN_INLINE v8::Local<v8::Primitive> NanUndefined() {

--- a/test/binding.gyp
+++ b/test/binding.gyp
@@ -100,4 +100,8 @@
         "target_name" : "threadlocal"
       , "sources"     : [ "cpp/threadlocal.cpp" ]
     }
+    , {
+        "target_name" : "objectwraphandle"
+      , "sources"     : [ "cpp/objectwraphandle.cpp" ]
+    }
 ]}

--- a/test/cpp/objectwraphandle.cpp
+++ b/test/cpp/objectwraphandle.cpp
@@ -1,0 +1,61 @@
+/*********************************************************************
+ * NAN - Native Abstractions for Node.js
+ *
+ * Copyright (c) 2015 NAN contributors
+ *
+ * MIT License <https://github.com/rvagg/nan/blob/master/LICENSE.md>
+ ********************************************************************/
+
+#include <nan.h>
+
+class MyObject : public node::ObjectWrap {
+ public:
+  static void Init(v8::Handle<v8::Object> exports) {
+    NanScope();
+    v8::Local<v8::FunctionTemplate> tpl = NanNew<v8::FunctionTemplate>(New);
+    tpl->SetClassName(NanNew("MyObject"));
+    tpl->InstanceTemplate()->SetInternalFieldCount(1);
+
+    NODE_SET_PROTOTYPE_METHOD(tpl, "getHandle", GetHandle);
+
+    NanAssignPersistent(constructor, tpl->GetFunction());
+    exports->Set(NanNew("MyObject"), tpl->GetFunction());
+  }
+
+ private:
+  explicit MyObject(double value=0) : value_(value) {}
+  ~MyObject() {}
+
+  static NAN_METHOD(New) {
+    NanScope();
+
+    if (args.IsConstructCall()) {
+      double value = args[0]->IsUndefined() ? 0 : args[0]->NumberValue();
+      MyObject *obj = new MyObject(value);
+      obj->Wrap(args.This());
+      NanReturnThis();
+    } else {
+      const int argc = 1;
+      v8::Local<v8::Value> argv[argc] = {args[0]};
+      v8::Local<v8::Function> cons = NanNew(constructor);
+      NanReturnValue(cons->NewInstance(argc, argv));
+    }
+  }
+
+  static NAN_METHOD(GetHandle) {
+    NanScope();
+    MyObject* obj = node::ObjectWrap::Unwrap<MyObject>(args.This());
+    NanReturnValue(NanObjectWrapHandle(obj));
+  }
+
+  static v8::Persistent<v8::Function> constructor;
+  double value_;
+};
+
+v8::Persistent<v8::Function> MyObject::constructor;
+
+void Init(v8::Handle<v8::Object> exports) {
+  MyObject::Init(exports);
+}
+
+NODE_MODULE(objectwraphandle, Init)

--- a/test/js/objectwraphandle-test.js
+++ b/test/js/objectwraphandle-test.js
@@ -1,0 +1,22 @@
+/*********************************************************************
+ * NAN - Native Abstractions for Node.js
+ *
+ * Copyright (c) 2015 NAN contributors
+ *
+ * MIT License <https://github.com/rvagg/nan/blob/master/LICENSE.md>
+ ********************************************************************/
+
+const test     = require('tap').test
+    , testRoot = require('path').resolve(__dirname, '..')
+    , bindings = require('bindings')({ module_root: testRoot, bindings: 'objectwraphandle' });
+
+test('objectwraphandle', function (t) {
+  t.plan(3);
+
+  t.type(bindings.MyObject, 'function');
+
+  var obj = new bindings.MyObject(10);
+
+  t.type(obj.getHandle, 'function');
+  t.type(obj.getHandle(), 'object');
+});


### PR DESCRIPTION
This will be published ASAP as 1.8.1

Fixes a problem in https://github.com/iojs/nan/commit/0bc6d599f23bd00d389461ec4effa88cac7c9baf where the argument type was accidentally changed from pointer to reference.