### PR TITLE
Use <cstdlib> for abort()

### DIFF
--- a/nan.h
+++ b/nan.h
@@ -27,6 +27,7 @@
 #include <node_object_wrap.h>
 #include <cstring>
 #include <climits>
+#include <cstdlib>
 #if defined(_MSC_VER)
 # pragma warning( push )
 # pragma warning( disable : 4530 )


### PR DESCRIPTION
In https://github.com/sass/node-sass/issues/892
we have a report that node-sass compilation
may fail due to undefined abort().

I think we should not rely on node or uv to
include <stdlib.h> for us.

http://pubs.opengroup.org/onlinepubs/9699919799/functions/abort.html