### PR TITLE
No copy or move in NanCallback and NanAsyncWorker

### DIFF
--- a/nan.h
+++ b/nan.h
@@ -826,7 +826,7 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
     }
 
    private:
-    NAN_DISALLOW_ASSIGN_COPY(NanAsciiString)
+    NAN_DISALLOW_ASSIGN_COPY_MOVE(NanAsciiString)
 
     char *buf;
     int size;
@@ -857,7 +857,7 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
     }
 
    private:
-    NAN_DISALLOW_ASSIGN_COPY(NanUtf8String)
+    NAN_DISALLOW_ASSIGN_COPY_MOVE(NanUtf8String)
 
     char *buf;
     int size;
@@ -888,7 +888,7 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
     }
 
    private:
-    NAN_DISALLOW_ASSIGN_COPY(NanUcs2String)
+    NAN_DISALLOW_ASSIGN_COPY_MOVE(NanUcs2String)
 
     uint16_t *buf;
     int size;
@@ -1373,7 +1373,7 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
     }
 
    private:
-    NAN_DISALLOW_ASSIGN_COPY(NanAsciiString)
+    NAN_DISALLOW_ASSIGN_COPY_MOVE(NanAsciiString)
 
     char *buf;
     int size;
@@ -1404,7 +1404,7 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
     }
 
    private:
-    NAN_DISALLOW_ASSIGN_COPY(NanUtf8String)
+    NAN_DISALLOW_ASSIGN_COPY_MOVE(NanUtf8String)
 
     char *buf;
     int size;
@@ -1435,7 +1435,7 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
     }
 
    private:
-    NAN_DISALLOW_ASSIGN_COPY(NanUcs2String)
+    NAN_DISALLOW_ASSIGN_COPY_MOVE(NanUcs2String)
 
     uint16_t *buf;
     int size;

--- a/nan.h
+++ b/nan.h
@@ -1696,6 +1696,7 @@ class NanCallback {
   }
 
  private:
+  NAN_DISALLOW_ASSIGN_COPY_MOVE(NanAsyncWorker)
   char *errmsg_;
 };
 

--- a/nan.h
+++ b/nan.h
@@ -562,6 +562,9 @@ NAN_INLINE v8::Local<v8::Value> _NanEnsureLocal(T val) {
     P* const parameter;
     Callback const callback;
     v8::Persistent<T> persistent;
+
+   private:
+    NAN_DISALLOW_ASSIGN_COPY_MOVE(_NanWeakCallbackInfo)
   };
 
   template<typename T, typename P>
@@ -1079,6 +1082,9 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
     P* const parameter;
     Callback const callback;
     v8::Persistent<T> persistent;
+
+   private:
+    NAN_DISALLOW_ASSIGN_COPY_MOVE(_NanWeakCallbackInfo)
   };
 
   template<typename T, typename P>

--- a/nan.h
+++ b/nan.h
@@ -1566,6 +1566,7 @@ class NanCallback {
   }
 
  private:
+  NAN_DISALLOW_ASSIGN_COPY_MOVE(NanCallback)
   v8::Persistent<v8::Object> handle;
   static const uint32_t kCallbackIndex = 0;
 

--- a/nan.h
+++ b/nan.h
@@ -55,6 +55,35 @@
 # define NAN_DEPRECATED
 #endif
 
+#if __cplusplus >= 201103L
+# define NAN_DISALLOW_ASSIGN(CLASS) void operator=(const CLASS&) = delete;
+# define NAN_DISALLOW_COPY(CLASS) CLASS(const CLASS&) = delete;
+# define NAN_DISALLOW_MOVE(CLASS)                                              \
+    CLASS(CLASS&&) = delete;                                                   \
+    void operator=(CLASS&&) = delete;
+#else
+# define NAN_DISALLOW_ASSIGN(CLASS) void operator=(const CLASS&);
+# define NAN_DISALLOW_COPY(CLASS) CLASS(const CLASS&);
+# define NAN_DISALLOW_MOVE(CLASS)
+#endif
+
+#define NAN_DISALLOW_ASSIGN_COPY(CLASS)                                        \
+    NAN_DISALLOW_ASSIGN(CLASS)                                                 \
+    NAN_DISALLOW_COPY(CLASS)
+
+#define NAN_DISALLOW_ASSIGN_MOVE(CLASS)                                        \
+    NAN_DISALLOW_ASSIGN(CLASS)                                                 \
+    NAN_DISALLOW_MOVE(CLASS)
+
+#define NAN_DISALLOW_COPY_MOVE(CLASS)                                          \
+    NAN_DISALLOW_COPY(CLASS)                                                   \
+    NAN_DISALLOW_MOVE(CLASS)
+
+#define NAN_DISALLOW_ASSIGN_COPY_MOVE(CLASS)                                   \
+    NAN_DISALLOW_ASSIGN(CLASS)                                                 \
+    NAN_DISALLOW_COPY(CLASS)                                                   \
+    NAN_DISALLOW_MOVE(CLASS)
+
 #define NODE_0_10_MODULE_VERSION 11
 #define NODE_0_12_MODULE_VERSION 12
 #define ATOM_0_21_MODULE_VERSION 41
@@ -797,9 +826,7 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
     }
 
    private:
-    // disallow copying and assigning
-    NanAsciiString(const NanAsciiString&);
-    void operator=(const NanAsciiString&);
+    NAN_DISALLOW_ASSIGN_COPY(NanAsciiString)
 
     char *buf;
     int size;
@@ -830,9 +857,7 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
     }
 
    private:
-    // disallow copying and assigning
-    NanUtf8String(const NanUtf8String&);
-    void operator=(const NanUtf8String&);
+    NAN_DISALLOW_ASSIGN_COPY(NanUtf8String)
 
     char *buf;
     int size;
@@ -863,9 +888,7 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
     }
 
    private:
-    // disallow copying and assigning
-    NanUcs2String(const NanUcs2String&);
-    void operator=(const NanUcs2String&);
+    NAN_DISALLOW_ASSIGN_COPY(NanUcs2String)
 
     uint16_t *buf;
     int size;
@@ -1350,9 +1373,7 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
     }
 
    private:
-    // disallow copying and assigning
-    NanAsciiString(const NanAsciiString&);
-    void operator=(const NanAsciiString&);
+    NAN_DISALLOW_ASSIGN_COPY(NanAsciiString)
 
     char *buf;
     int size;
@@ -1383,9 +1404,7 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
     }
 
    private:
-    // disallow copying and assigning
-    NanUtf8String(const NanUtf8String&);
-    void operator=(const NanUtf8String&);
+    NAN_DISALLOW_ASSIGN_COPY(NanUtf8String)
 
     char *buf;
     int size;
@@ -1416,9 +1435,7 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
     }
 
    private:
-    // disallow copying and assigning
-    NanUcs2String(const NanUcs2String&);
-    void operator=(const NanUcs2String&);
+    NAN_DISALLOW_ASSIGN_COPY(NanUcs2String)
 
     uint16_t *buf;
     int size;
@@ -1722,14 +1739,7 @@ class NanCallback {
 
    private:
     explicit ExecutionProgress(NanAsyncProgressWorker* that) : that_(that) {}
-    // Prohibit copying and assignment.
-    ExecutionProgress(const ExecutionProgress&);
-    void operator=(const ExecutionProgress&);
-  #if __cplusplus >= 201103L
-    // Prohibit C++11 move semantics.
-    ExecutionProgress(ExecutionProgress&&) = delete;
-    void operator=(ExecutionProgress&&) = delete;
-  #endif
+    NAN_DISALLOW_ASSIGN_COPY_MOVE(ExecutionProgress)
     NanAsyncProgressWorker* const that_;
   };
 


### PR DESCRIPTION
Fixes #330
Made the same changes to `NanAsyncWorker`, since it too contains a `Persistent<T>`.
PTAL