### PR TITLE
Nomacro

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,8 +176,6 @@ using v8::Number;
 
 // Simple synchronous access to the `Estimate()` function
 NAN_METHOD(CalculateSync) {
-  NanScope();
-
   // expect a number as the first argument
   int points = args[0]->Uint32Value();
   double est = Estimate(points);
@@ -243,8 +241,6 @@ class PiWorker : public NanAsyncWorker {
 
 // Asynchronous access to the `Estimate()` function
 NAN_METHOD(CalculateAsync) {
-  NanScope();
-
   int points = args[0]->Uint32Value();
   NanCallback *callback = new NanCallback(args[1].As<Function>());
 
@@ -455,7 +451,6 @@ NAN_GC_CALLBACK(gcPrologueCallback) {
 }
 
 NAN_METHOD(Hook) {
-  NanScope();
   NanAssignPersistent(callback, args[0].As<Function>());
   NanAddGCPrologueCallback(gcPrologueCallback);
   NanReturnValue(args.Holder());
@@ -629,12 +624,10 @@ NAN_METHOD(Foo::Baz) {
 <a name="api_nan_scope"></a>
 ### NanScope()
 
-The introduction of `isolate` references for many V8 calls in Node 0.11 makes `NanScope()` necessary, use it in place of `HandleScope scope` when you do not wish to return handles (`Handle` or `Local`) to the surrounding scope (or in functions directly exposed to V8, as they do not return values in the normal sense):
+The introduction of `isolate` references for many V8 calls in Node 0.11 makes `NanScope()` necessary, use it in place of `HandleScope scope` when you do not wish to return handles (`Handle` or `Local`) to the surrounding scope (or in functions directly exposed to V8, as they do not return values in the normal sense). V8-exposed methods (NAN_METHOD, etc.) have implicit handle scopes and do not need extra scopes:
 
 ```c++
 NAN_METHOD(Foo::Bar) {
-  NanScope();
-
   NanReturnValue(NanNew<String>("FooBar!"));
 }
 ```
@@ -807,7 +800,6 @@ Convert a `String` to zero-terminated, sort-of Ascii-encoded `char *`. The under
 
 ```c++
 NAN_METHOD(foo) {
-  NanScope();
   NanReturnValue(NanNew(*NanAsciiString(arg[0])));
 }
 ```
@@ -818,7 +810,6 @@ the buffer `str` points to has been freed when `baz` was destroyed:
 static char *str;
 
 NAN_METHOD(bar) {
-  NanScope();
   NanAsciiString baz(arg[0]);
 
   str = *baz;
@@ -835,7 +826,6 @@ printf(str); // use-after-free error
 static NanAsciiString *str;
 
 NAN_METHOD(bar) {
-  NanScope();
   str = new NanAsciiString(arg[0]);
   NanReturnUndefined();
 }
@@ -853,7 +843,6 @@ Convert a `String` to zero-terminated, Utf8-encoded `char *`. The underlying buf
 
 ```c++
 NAN_METHOD(foo) {
-  NanScope();
   NanReturnValue(NanNew(*NanUtf8String(arg[0])));
 }
 ```
@@ -864,7 +853,6 @@ the buffer `str` points to has been freed when `baz` was destroyed:
 static char *str;
 
 NAN_METHOD(bar) {
-  NanScope();
   NanUtf8String baz(arg[0]);
 
   str = *baz;
@@ -881,7 +869,6 @@ printf(str); // use-after-free error
 static NanUtf8String *str;
 
 NAN_METHOD(bar) {
-  NanScope();
   str = new NanUtf8String(arg[0]);
   NanReturnUndefined();
 }
@@ -900,7 +887,6 @@ Convert a `String` to zero-terminated, Ucs2-encoded `uint16_t *`. The underlying
 
 ```c++
 NAN_METHOD(foo) {
-  NanScope();
   NanReturnValue(NanNew(*NanUcs2String(arg[0])));
 }
 ```
@@ -911,7 +897,6 @@ the buffer `str` points to has been freed when `baz` was destroyed:
 static char *str;
 
 NAN_METHOD(bar) {
-  NanScope();
   NanUcs2String baz(arg[0]);
 
   str = *baz;
@@ -928,7 +913,6 @@ printf(str); // use-after-free error
 static NanUcs2String *str;
 
 NAN_METHOD(bar) {
-  NanScope();
   str = new NanUcs2String(arg[0]);
   NanReturnUndefined();
 }

--- a/examples/async_pi_estimate/async.cc
+++ b/examples/async_pi_estimate/async.cc
@@ -51,8 +51,6 @@ class PiWorker : public NanAsyncWorker {
 
 // Asynchronous access to the `Estimate()` function
 NAN_METHOD(CalculateAsync) {
-  NanScope();
-
   int points = args[0]->Uint32Value();
   NanCallback *callback = new NanCallback(args[1].As<Function>());
 

--- a/examples/async_pi_estimate/sync.cc
+++ b/examples/async_pi_estimate/sync.cc
@@ -14,8 +14,6 @@ using v8::Number;
 
 // Simple synchronous access to the `Estimate()` function
 NAN_METHOD(CalculateSync) {
-  NanScope();
-
   // expect a number as the first argument
   int points = args[0]->Uint32Value();
   double est = Estimate(points);

--- a/nan.h
+++ b/nan.h
@@ -324,71 +324,53 @@ namespace Nan { namespace imp {
   }
 #endif
 
-#if (NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION)
-// Node 0.11+ (0.11.12 and below won't compile with these)
+#if (NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION)  // Node 0.12
+  typedef const v8::FunctionCallbackInfo<v8::Value>& NAN_METHOD_ARGS_TYPE;
+  typedef void NAN_METHOD_RETURN_TYPE;
 
-# define _NAN_METHOD_ARGS_TYPE const v8::FunctionCallbackInfo<v8::Value>&
-# define _NAN_METHOD_ARGS _NAN_METHOD_ARGS_TYPE args
-# define _NAN_METHOD_RETURN_TYPE void
+  typedef const v8::PropertyCallbackInfo<v8::Value>& NAN_GETTER_ARGS_TYPE;
+  typedef void NAN_GETTER_RETURN_TYPE;
 
-# define _NAN_GETTER_ARGS_TYPE const v8::PropertyCallbackInfo<v8::Value>&
-# define _NAN_GETTER_ARGS _NAN_GETTER_ARGS_TYPE args
-# define _NAN_GETTER_RETURN_TYPE void
+  typedef const v8::PropertyCallbackInfo<void>& NAN_SETTER_ARGS_TYPE;
+  typedef void NAN_SETTER_RETURN_TYPE;
 
-# define _NAN_SETTER_ARGS_TYPE const v8::PropertyCallbackInfo<void>&
-# define _NAN_SETTER_ARGS _NAN_SETTER_ARGS_TYPE args
-# define _NAN_SETTER_RETURN_TYPE void
+  typedef const v8::PropertyCallbackInfo<v8::Value>&
+      NAN_PROPERTY_GETTER_ARGS_TYPE;
+  typedef void NAN_PROPERTY_GETTER_RETURN_TYPE;
 
-# define _NAN_PROPERTY_GETTER_ARGS_TYPE                                        \
-    const v8::PropertyCallbackInfo<v8::Value>&
-# define _NAN_PROPERTY_GETTER_ARGS _NAN_PROPERTY_GETTER_ARGS_TYPE args
-# define _NAN_PROPERTY_GETTER_RETURN_TYPE void
+  typedef const v8::PropertyCallbackInfo<v8::Value>&
+      NAN_PROPERTY_SETTER_ARGS_TYPE;
+  typedef void NAN_PROPERTY_SETTER_RETURN_TYPE;
 
-# define _NAN_PROPERTY_SETTER_ARGS_TYPE                                        \
-    const v8::PropertyCallbackInfo<v8::Value>&
-# define _NAN_PROPERTY_SETTER_ARGS _NAN_PROPERTY_SETTER_ARGS_TYPE args
-# define _NAN_PROPERTY_SETTER_RETURN_TYPE void
+  typedef const v8::PropertyCallbackInfo<v8::Array>&
+      NAN_PROPERTY_ENUMERATOR_ARGS_TYPE;
+  typedef void NAN_PROPERTY_ENUMERATOR_RETURN_TYPE;
 
-# define _NAN_PROPERTY_ENUMERATOR_ARGS_TYPE                                    \
-    const v8::PropertyCallbackInfo<v8::Array>&
-# define _NAN_PROPERTY_ENUMERATOR_ARGS _NAN_PROPERTY_ENUMERATOR_ARGS_TYPE args
-# define _NAN_PROPERTY_ENUMERATOR_RETURN_TYPE void
+  typedef const v8::PropertyCallbackInfo<v8::Boolean>&
+      NAN_PROPERTY_DELETER_ARGS_TYPE;
+  typedef void NAN_PROPERTY_DELETER_RETURN_TYPE;
 
-# define _NAN_PROPERTY_DELETER_ARGS_TYPE                                       \
-    const v8::PropertyCallbackInfo<v8::Boolean>&
-# define _NAN_PROPERTY_DELETER_ARGS                                            \
-    _NAN_PROPERTY_DELETER_ARGS_TYPE args
-# define _NAN_PROPERTY_DELETER_RETURN_TYPE void
+  typedef const v8::PropertyCallbackInfo<v8::Integer>&
+      NAN_PROPERTY_QUERY_ARGS_TYPE;
+  typedef void NAN_PROPERTY_QUERY_RETURN_TYPE;
 
-# define _NAN_PROPERTY_QUERY_ARGS_TYPE                                         \
-    const v8::PropertyCallbackInfo<v8::Integer>&
-# define _NAN_PROPERTY_QUERY_ARGS _NAN_PROPERTY_QUERY_ARGS_TYPE args
-# define _NAN_PROPERTY_QUERY_RETURN_TYPE void
+  typedef const v8::PropertyCallbackInfo<v8::Value>& NAN_INDEX_GETTER_ARGS_TYPE;
+  typedef void NAN_INDEX_GETTER_RETURN_TYPE;
 
-# define _NAN_INDEX_GETTER_ARGS_TYPE                                           \
-    const v8::PropertyCallbackInfo<v8::Value>&
-# define _NAN_INDEX_GETTER_ARGS _NAN_INDEX_GETTER_ARGS_TYPE args
-# define _NAN_INDEX_GETTER_RETURN_TYPE void
+  typedef const v8::PropertyCallbackInfo<v8::Value>& NAN_INDEX_SETTER_ARGS_TYPE;
+  typedef void NAN_INDEX_SETTER_RETURN_TYPE;
 
-# define _NAN_INDEX_SETTER_ARGS_TYPE                                           \
-    const v8::PropertyCallbackInfo<v8::Value>&
-# define _NAN_INDEX_SETTER_ARGS _NAN_INDEX_SETTER_ARGS_TYPE args
-# define _NAN_INDEX_SETTER_RETURN_TYPE void
+  typedef const v8::PropertyCallbackInfo<v8::Array>&
+      NAN_INDEX_ENUMERATOR_ARGS_TYPE;
+  typedef void NAN_INDEX_ENUMERATOR_RETURN_TYPE;
 
-# define _NAN_INDEX_ENUMERATOR_ARGS_TYPE                                       \
-    const v8::PropertyCallbackInfo<v8::Array>&
-# define _NAN_INDEX_ENUMERATOR_ARGS _NAN_INDEX_ENUMERATOR_ARGS_TYPE args
-# define _NAN_INDEX_ENUMERATOR_RETURN_TYPE void
+  typedef const v8::PropertyCallbackInfo<v8::Boolean>&
+      NAN_INDEX_DELETER_ARGS_TYPE;
+  typedef void NAN_INDEX_DELETER_RETURN_TYPE;
 
-# define _NAN_INDEX_DELETER_ARGS_TYPE                                          \
-    const v8::PropertyCallbackInfo<v8::Boolean>&
-# define _NAN_INDEX_DELETER_ARGS _NAN_INDEX_DELETER_ARGS_TYPE args
-# define _NAN_INDEX_DELETER_RETURN_TYPE void
-
-# define _NAN_INDEX_QUERY_ARGS_TYPE                                            \
-    const v8::PropertyCallbackInfo<v8::Integer>&
-# define _NAN_INDEX_QUERY_ARGS _NAN_INDEX_QUERY_ARGS_TYPE args
-# define _NAN_INDEX_QUERY_RETURN_TYPE void
+  typedef const v8::PropertyCallbackInfo<v8::Integer>&
+      NAN_INDEX_QUERY_ARGS_TYPE;
+  typedef void NAN_INDEX_QUERY_RETURN_TYPE;
 
 # define NanScope() v8::HandleScope scope(v8::Isolate::GetCurrent())
 # define NanEscapableScope()                                                   \
@@ -398,7 +380,7 @@ namespace Nan { namespace imp {
 # define NanLocker() v8::Locker locker(v8::Isolate::GetCurrent())
 # define NanUnlocker() v8::Unlocker unlocker(v8::Isolate::GetCurrent())
 # define NanReturnValue(value)                                                 \
-return args.GetReturnValue().Set(Nan::imp::NanEnsureHandleOrPersistent(value))
+  return args.GetReturnValue().Set(Nan::imp::NanEnsureHandleOrPersistent(value))
 # define NanReturnUndefined() return
 # define NanReturnHolder() NanReturnValue(args.Holder())
 # define NanReturnThis() NanReturnValue(args.This())
@@ -761,60 +743,45 @@ return args.GetReturnValue().Set(Nan::imp::NanEnsureHandleOrPersistent(value))
     int size;
   };
 
-#else
-// Node 0.8 and 0.10
+#else  // Node 0.8 and 0.10
+  typedef const v8::Arguments& NAN_METHOD_ARGS_TYPE;
+  typedef v8::Handle<v8::Value> NAN_METHOD_RETURN_TYPE;
 
-# define _NAN_METHOD_ARGS_TYPE const v8::Arguments&
-# define _NAN_METHOD_ARGS _NAN_METHOD_ARGS_TYPE args
-# define _NAN_METHOD_RETURN_TYPE v8::Handle<v8::Value>
+  typedef const v8::AccessorInfo & NAN_GETTER_ARGS_TYPE;
+  typedef v8::Handle<v8::Value> NAN_GETTER_RETURN_TYPE;
 
-# define _NAN_GETTER_ARGS_TYPE const v8::AccessorInfo &
-# define _NAN_GETTER_ARGS _NAN_GETTER_ARGS_TYPE args
-# define _NAN_GETTER_RETURN_TYPE v8::Handle<v8::Value>
+  typedef const v8::AccessorInfo & NAN_SETTER_ARGS_TYPE;
+  typedef void NAN_SETTER_RETURN_TYPE;
 
-# define _NAN_SETTER_ARGS_TYPE const v8::AccessorInfo &
-# define _NAN_SETTER_ARGS _NAN_SETTER_ARGS_TYPE args
-# define _NAN_SETTER_RETURN_TYPE void
+  typedef const v8::AccessorInfo& NAN_PROPERTY_GETTER_ARGS_TYPE;
+  typedef v8::Handle<v8::Value> NAN_PROPERTY_GETTER_RETURN_TYPE;
 
-# define _NAN_PROPERTY_GETTER_ARGS_TYPE const v8::AccessorInfo&
-# define _NAN_PROPERTY_GETTER_ARGS _NAN_PROPERTY_GETTER_ARGS_TYPE args
-# define _NAN_PROPERTY_GETTER_RETURN_TYPE v8::Handle<v8::Value>
+  typedef const v8::AccessorInfo& NAN_PROPERTY_SETTER_ARGS_TYPE;
+  typedef v8::Handle<v8::Value> NAN_PROPERTY_SETTER_RETURN_TYPE;
 
-# define _NAN_PROPERTY_SETTER_ARGS_TYPE const v8::AccessorInfo&
-# define _NAN_PROPERTY_SETTER_ARGS _NAN_PROPERTY_SETTER_ARGS_TYPE args
-# define _NAN_PROPERTY_SETTER_RETURN_TYPE v8::Handle<v8::Value>
+  typedef const v8::AccessorInfo& NAN_PROPERTY_ENUMERATOR_ARGS_TYPE;
+  typedef v8::Handle<v8::Array> NAN_PROPERTY_ENUMERATOR_RETURN_TYPE;
 
-# define _NAN_PROPERTY_ENUMERATOR_ARGS_TYPE const v8::AccessorInfo&
-# define _NAN_PROPERTY_ENUMERATOR_ARGS _NAN_PROPERTY_ENUMERATOR_ARGS_TYPE args
-# define _NAN_PROPERTY_ENUMERATOR_RETURN_TYPE v8::Handle<v8::Array>
+  typedef const v8::AccessorInfo& NAN_PROPERTY_DELETER_ARGS_TYPE;
+  typedef v8::Handle<v8::Boolean> NAN_PROPERTY_DELETER_RETURN_TYPE;
 
-# define _NAN_PROPERTY_DELETER_ARGS_TYPE const v8::AccessorInfo&
-# define _NAN_PROPERTY_DELETER_ARGS _NAN_PROPERTY_DELETER_ARGS_TYPE args
-# define _NAN_PROPERTY_DELETER_RETURN_TYPE v8::Handle<v8::Boolean>
+  typedef const v8::AccessorInfo& NAN_PROPERTY_QUERY_ARGS_TYPE;
+  typedef v8::Handle<v8::Integer> NAN_PROPERTY_QUERY_RETURN_TYPE;
 
-# define _NAN_PROPERTY_QUERY_ARGS_TYPE const v8::AccessorInfo&
-# define _NAN_PROPERTY_QUERY_ARGS _NAN_PROPERTY_QUERY_ARGS_TYPE args
-# define _NAN_PROPERTY_QUERY_RETURN_TYPE v8::Handle<v8::Integer>
+  typedef const v8::AccessorInfo& NAN_INDEX_GETTER_ARGS_TYPE;
+  typedef v8::Handle<v8::Value> NAN_INDEX_GETTER_RETURN_TYPE;
 
-# define _NAN_INDEX_GETTER_ARGS_TYPE const v8::AccessorInfo&
-# define _NAN_INDEX_GETTER_ARGS _NAN_INDEX_GETTER_ARGS_TYPE args
-# define _NAN_INDEX_GETTER_RETURN_TYPE v8::Handle<v8::Value>
+  typedef const v8::AccessorInfo& NAN_INDEX_SETTER_ARGS_TYPE;
+  typedef v8::Handle<v8::Value> NAN_INDEX_SETTER_RETURN_TYPE;
 
-# define _NAN_INDEX_SETTER_ARGS_TYPE const v8::AccessorInfo&
-# define _NAN_INDEX_SETTER_ARGS _NAN_INDEX_SETTER_ARGS_TYPE args
-# define _NAN_INDEX_SETTER_RETURN_TYPE v8::Handle<v8::Value>
+  typedef const v8::AccessorInfo& NAN_INDEX_ENUMERATOR_ARGS_TYPE;
+  typedef v8::Handle<v8::Array> NAN_INDEX_ENUMERATOR_RETURN_TYPE;
 
-# define _NAN_INDEX_ENUMERATOR_ARGS_TYPE const v8::AccessorInfo&
-# define _NAN_INDEX_ENUMERATOR_ARGS _NAN_INDEX_ENUMERATOR_ARGS_TYPE args
-# define _NAN_INDEX_ENUMERATOR_RETURN_TYPE v8::Handle<v8::Array>
+  typedef const v8::AccessorInfo& NAN_INDEX_DELETER_ARGS_TYPE;
+  typedef v8::Handle<v8::Boolean> NAN_INDEX_DELETER_RETURN_TYPE;
 
-# define _NAN_INDEX_DELETER_ARGS_TYPE const v8::AccessorInfo&
-# define _NAN_INDEX_DELETER_ARGS _NAN_INDEX_DELETER_ARGS_TYPE args
-# define _NAN_INDEX_DELETER_RETURN_TYPE v8::Handle<v8::Boolean>
-
-# define _NAN_INDEX_QUERY_ARGS_TYPE const v8::AccessorInfo&
-# define _NAN_INDEX_QUERY_ARGS _NAN_INDEX_QUERY_ARGS_TYPE args
-# define _NAN_INDEX_QUERY_RETURN_TYPE v8::Handle<v8::Integer>
+  typedef const v8::AccessorInfo& NAN_INDEX_QUERY_ARGS_TYPE;
+  typedef v8::Handle<v8::Integer> NAN_INDEX_QUERY_RETURN_TYPE;
 
 # define NanScope() v8::HandleScope scope
 # define NanEscapableScope() v8::HandleScope scope
@@ -1187,50 +1154,55 @@ return args.GetReturnValue().Set(Nan::imp::NanEnsureHandleOrPersistent(value))
 
 typedef void (*NanFreeCallback)(char *data, void *hint);
 
-#define NAN_METHOD(name) _NAN_METHOD_RETURN_TYPE name(_NAN_METHOD_ARGS)
+#define NAN_METHOD(name) NAN_METHOD_RETURN_TYPE name(NAN_METHOD_ARGS_TYPE args)
 #define NAN_GETTER(name)                                                       \
-    _NAN_GETTER_RETURN_TYPE name(                                              \
+    NAN_GETTER_RETURN_TYPE name(                                               \
         v8::Local<v8::String> property                                         \
-      , _NAN_GETTER_ARGS)
+      , NAN_GETTER_ARGS_TYPE args)
 #define NAN_SETTER(name)                                                       \
-    _NAN_SETTER_RETURN_TYPE name(                                              \
+    NAN_SETTER_RETURN_TYPE name(                                               \
         v8::Local<v8::String> property                                         \
       , v8::Local<v8::Value> value                                             \
-      , _NAN_SETTER_ARGS)
+      , NAN_SETTER_ARGS_TYPE args)
 #define NAN_PROPERTY_GETTER(name)                                              \
-    _NAN_PROPERTY_GETTER_RETURN_TYPE name(                                     \
+    NAN_PROPERTY_GETTER_RETURN_TYPE name(                                      \
         v8::Local<v8::String> property                                         \
-      , _NAN_PROPERTY_GETTER_ARGS)
+      , NAN_PROPERTY_GETTER_ARGS_TYPE args)
 #define NAN_PROPERTY_SETTER(name)                                              \
-    _NAN_PROPERTY_SETTER_RETURN_TYPE name(                                     \
+    NAN_PROPERTY_SETTER_RETURN_TYPE name(                                      \
         v8::Local<v8::String> property                                         \
       , v8::Local<v8::Value> value                                             \
-      , _NAN_PROPERTY_SETTER_ARGS)
+      , NAN_PROPERTY_SETTER_ARGS_TYPE args)
 #define NAN_PROPERTY_ENUMERATOR(name)                                          \
-    _NAN_PROPERTY_ENUMERATOR_RETURN_TYPE name(_NAN_PROPERTY_ENUMERATOR_ARGS)
+    NAN_PROPERTY_ENUMERATOR_RETURN_TYPE name(                                  \
+        NAN_PROPERTY_ENUMERATOR_ARGS_TYPE args)
 #define NAN_PROPERTY_DELETER(name)                                             \
-    _NAN_PROPERTY_DELETER_RETURN_TYPE name(                                    \
+    NAN_PROPERTY_DELETER_RETURN_TYPE name(                                     \
         v8::Local<v8::String> property                                         \
-      , _NAN_PROPERTY_DELETER_ARGS)
+      , NAN_PROPERTY_DELETER_ARGS_TYPE args)
 #define NAN_PROPERTY_QUERY(name)                                               \
-    _NAN_PROPERTY_QUERY_RETURN_TYPE name(                                      \
+    NAN_PROPERTY_QUERY_RETURN_TYPE name(                                       \
         v8::Local<v8::String> property                                         \
-      , _NAN_PROPERTY_QUERY_ARGS)
+      , NAN_PROPERTY_QUERY_ARGS_TYPE args)
 # define NAN_INDEX_GETTER(name)                                                \
-    _NAN_INDEX_GETTER_RETURN_TYPE name(uint32_t index, _NAN_INDEX_GETTER_ARGS)
+    NAN_INDEX_GETTER_RETURN_TYPE name(                                         \
+        uint32_t index                                                         \
+      , NAN_INDEX_GETTER_ARGS_TYPE args)
 #define NAN_INDEX_SETTER(name)                                                 \
-    _NAN_INDEX_SETTER_RETURN_TYPE name(                                        \
+    NAN_INDEX_SETTER_RETURN_TYPE name(                                         \
         uint32_t index                                                         \
       , v8::Local<v8::Value> value                                             \
-      , _NAN_INDEX_SETTER_ARGS)
+      , NAN_INDEX_SETTER_ARGS_TYPE args)
 #define NAN_INDEX_ENUMERATOR(name)                                             \
-    _NAN_INDEX_ENUMERATOR_RETURN_TYPE name(_NAN_INDEX_ENUMERATOR_ARGS)
+    NAN_INDEX_ENUMERATOR_RETURN_TYPE name(NAN_INDEX_ENUMERATOR_ARGS_TYPE args)
 #define NAN_INDEX_DELETER(name)                                                \
-    _NAN_INDEX_DELETER_RETURN_TYPE name(                                       \
+    NAN_INDEX_DELETER_RETURN_TYPE name(                                        \
         uint32_t index                                                         \
-      , _NAN_INDEX_DELETER_ARGS)
+      , NAN_INDEX_DELETER_ARGS_TYPE args)
 #define NAN_INDEX_QUERY(name)                                                  \
-    _NAN_INDEX_QUERY_RETURN_TYPE name(uint32_t index, _NAN_INDEX_QUERY_ARGS)
+    NAN_INDEX_QUERY_RETURN_TYPE name(                                          \
+        uint32_t index                                                         \
+      , NAN_INDEX_QUERY_ARGS_TYPE args)
 
 class NanCallback {
  public:

--- a/nan.h
+++ b/nan.h
@@ -1231,16 +1231,7 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
     , v8::Handle<v8::Function> func
     , int argc
     , v8::Handle<v8::Value>* argv) {
-# if NODE_VERSION_AT_LEAST(0, 8, 0)
     return NanNew(node::MakeCallback(target, func, argc, argv));
-# else
-    v8::TryCatch try_catch;
-    v8::Local<v8::Value> result = func->Call(target, argc, argv);
-    if (try_catch.HasCaught()) {
-        node::FatalException(try_catch);
-    }
-    return result;
-# endif
   }
 
   NAN_INLINE v8::Local<v8::Value> NanMakeCallback(
@@ -1248,12 +1239,7 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
     , v8::Handle<v8::String> symbol
     , int argc
     , v8::Handle<v8::Value>* argv) {
-# if NODE_VERSION_AT_LEAST(0, 8, 0)
     return NanNew(node::MakeCallback(target, symbol, argc, argv));
-# else
-    v8::Local<v8::Function> callback = target->Get(symbol).As<v8::Function>();
-    return NanMakeCallback(target, callback, argc, argv);
-# endif
   }
 
   NAN_INLINE v8::Local<v8::Value> NanMakeCallback(
@@ -1261,11 +1247,7 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
     , const char* method
     , int argc
     , v8::Handle<v8::Value>* argv) {
-# if NODE_VERSION_AT_LEAST(0, 8, 0)
     return NanNew(node::MakeCallback(target, method, argc, argv));
-# else
-    return NanMakeCallback(target, NanNew(method), argc, argv);
-# endif
   }
 
   NAN_INLINE void NanFatalException(const v8::TryCatch& try_catch) {
@@ -1515,7 +1497,6 @@ class NanCallback {
                            , v8::Handle<v8::Value> argv[]) const {
     NanEscapableScope();
 
-#if NODE_VERSION_AT_LEAST(0, 8, 0)
     v8::Local<v8::Function> callback = handle->
         Get(kCallbackIndex).As<v8::Function>();
     return NanEscapeScope(node::MakeCallback(
@@ -1524,12 +1505,6 @@ class NanCallback {
       , argc
       , argv
     ));
-#else
-    v8::Local<v8::Function> callback = handle->
-        Get(kCallbackIndex).As<v8::Function>();
-    return NanEscapeScope(NanMakeCallback(
-        target, callback, argc, argv));
-#endif
   }
 #endif
 };

--- a/nan.h
+++ b/nan.h
@@ -219,91 +219,6 @@ inline void nauv_key_set(nauv_key_t* key, void* value) {
 #endif
 #endif
 
-// some generic helpers
-
-namespace Nan { namespace imp {
-template<typename T> NAN_INLINE bool NanSetPointerSafe(
-    T *var
-  , T val
-) {
-  if (var) {
-    *var = val;
-    return true;
-  } else {
-    return false;
-  }
-}
-
-template<typename T> NAN_INLINE T NanGetPointerSafe(
-    T *var
-  , T fallback = reinterpret_cast<T>(0)
-) {
-  if (var) {
-    return *var;
-  } else {
-    return fallback;
-  }
-}
-
-NAN_INLINE bool NanBooleanOptionValue(
-    v8::Local<v8::Object> optionsObj
-  , v8::Handle<v8::String> opt, bool def
-) {
-  if (def) {
-    return optionsObj.IsEmpty()
-      || !optionsObj->Has(opt)
-      || optionsObj->Get(opt)->BooleanValue();
-  } else {
-    return !optionsObj.IsEmpty()
-      && optionsObj->Has(opt)
-      && optionsObj->Get(opt)->BooleanValue();
-  }
-}
-
-}  // end of namespace imp
-}  // end of namespace Nan
-
-template<typename T> NAN_DEPRECATED NAN_INLINE bool NanSetPointerSafe(
-    T *var
-  , T val
-) {
-  return Nan::imp::NanSetPointerSafe<T>(var, val);
-}
-
-template<typename T> NAN_DEPRECATED NAN_INLINE T NanGetPointerSafe(
-    T *var
-  , T fallback = reinterpret_cast<T>(0)
-) {
-  return Nan::imp::NanGetPointerSafe(var, fallback);
-}
-
-
-NAN_DEPRECATED NAN_INLINE bool NanBooleanOptionValue(
-    v8::Local<v8::Object> optionsObj
-  , v8::Handle<v8::String> opt, bool def
-) {
-  return Nan::imp::NanBooleanOptionValue(optionsObj, opt, def);
-}
-
-NAN_DEPRECATED NAN_INLINE bool NanBooleanOptionValue(
-    v8::Local<v8::Object> optionsObj
-  , v8::Handle<v8::String> opt
-) {
-  return Nan::imp::NanBooleanOptionValue(optionsObj, opt, false);
-}
-
-NAN_DEPRECATED NAN_INLINE uint32_t NanUInt32OptionValue(
-    v8::Local<v8::Object> optionsObj
-  , v8::Handle<v8::String> opt
-  , uint32_t def
-) {
-  return !optionsObj.IsEmpty()
-    && optionsObj->Has(opt)
-    && optionsObj->Get(opt)->IsNumber()
-      ? optionsObj->Get(opt)->Uint32Value()
-      : def;
-}
-
 template<typename T>
 v8::Local<T> NanNew(v8::Handle<T>);
 
@@ -583,11 +498,6 @@ return args.GetReturnValue().Set(Nan::imp::NanEnsureHandleOrPersistent(value))
     v8::Isolate::GetCurrent()->GetHeapStatistics(heap_statistics);
   }
 
-  NAN_DEPRECATED NAN_INLINE v8::Local<v8::String> NanSymbol(
-      const char* data, int length = -1) {
-    return NanNew<v8::String>(data, length);
-  }
-
   template<typename T>
   NAN_INLINE void NanAssignPersistent(
       v8::Persistent<T>& handle
@@ -645,9 +555,6 @@ return args.GetReturnValue().Set(Nan::imp::NanEnsureHandleOrPersistent(value))
 
     NAN_INLINE _NanWeakCallbackInfo<T, P>* GetCallbackInfo() const {
       return info_;
-    }
-
-    NAN_DEPRECATED NAN_INLINE void Dispose() const {
     }
 
    private:
@@ -780,18 +687,6 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
     return NanNew(function_template)->HasInstance(value);
   }
 
-  NAN_DEPRECATED NAN_INLINE v8::Local<v8::Context> NanNewContextHandle(
-      v8::ExtensionConfiguration* extensions = NULL
-    , v8::Handle<v8::ObjectTemplate> tmpl = v8::Handle<v8::ObjectTemplate>()
-    , v8::Handle<v8::Value> obj = v8::Handle<v8::Value>()
-  ) {
-    v8::Isolate* isolate = v8::Isolate::GetCurrent();
-    return v8::Local<v8::Context>::New(
-        isolate
-      , v8::Context::New(isolate, extensions, tmpl, obj)
-    );
-  }
-
   NAN_INLINE v8::Local<NanBoundScript> NanCompileScript(
       v8::Local<v8::String> s
     , const v8::ScriptOrigin& origin
@@ -874,10 +769,6 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
       size = toStr->WriteOneByte(reinterpret_cast<unsigned char*>(buf));
     }
 
-    NAN_DEPRECATED NAN_INLINE int Size() const {
-      return size;
-    }
-
     NAN_INLINE int length() const {
       return size;
     }
@@ -906,10 +797,6 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
       toStr->WriteUtf8(buf);
     }
 
-    NAN_DEPRECATED NAN_INLINE int Size() const {
-      return size;
-    }
-
     NAN_INLINE int length() const {
       return size;
     }
@@ -935,10 +822,6 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
       size = toStr->Length();
       buf = new uint16_t[size + 1];
       toStr->Write(buf);
-    }
-
-    NAN_DEPRECATED NAN_INLINE int Size() const {
-      return size;
     }
 
     NAN_INLINE int length() const {
@@ -1013,11 +896,6 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
 # define _NAN_INDEX_QUERY_ARGS_TYPE const v8::AccessorInfo&
 # define _NAN_INDEX_QUERY_ARGS _NAN_INDEX_QUERY_ARGS_TYPE args
 # define _NAN_INDEX_QUERY_RETURN_TYPE v8::Handle<v8::Integer>
-
-  NAN_DEPRECATED NAN_INLINE v8::Local<v8::String> NanSymbol(
-      const char* data, int length = -1) {
-    return v8::String::NewSymbol(data, length);
-  }
 
 # define NanScope() v8::HandleScope scope
 # define NanEscapableScope() v8::HandleScope scope
@@ -1171,9 +1049,6 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
 
     NAN_INLINE _NanWeakCallbackInfo<T, P>* GetCallbackInfo() const {
       return info_;
-    }
-
-    NAN_DEPRECATED NAN_INLINE void Dispose() const {
     }
 
    private:
@@ -1334,17 +1209,6 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
     return function_template->HasInstance(value);
   }
 
-  NAN_DEPRECATED NAN_INLINE v8::Local<v8::Context> NanNewContextHandle(
-      v8::ExtensionConfiguration* extensions = NULL
-    , v8::Handle<v8::ObjectTemplate> tmpl = v8::Handle<v8::ObjectTemplate>()
-    , v8::Handle<v8::Value> obj = v8::Handle<v8::Value>()
-  ) {
-    v8::Persistent<v8::Context> ctx = v8::Context::New(extensions, tmpl, obj);
-    v8::Local<v8::Context> lctx = NanNew(ctx);
-    ctx.Dispose();
-    return lctx;
-  }
-
   NAN_INLINE v8::Local<NanBoundScript> NanCompileScript(
       v8::Local<v8::String> s
     , const v8::ScriptOrigin& origin
@@ -1432,10 +1296,6 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
       size = toStr->WriteAscii(buf);
     }
 
-    NAN_DEPRECATED NAN_INLINE int Size() const {
-      return size;
-    }
-
     NAN_INLINE int length() const {
       return size;
     }
@@ -1464,10 +1324,6 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
       toStr->WriteUtf8(buf);
     }
 
-    NAN_DEPRECATED NAN_INLINE int Size() const {
-      return size;
-    }
-
     NAN_INLINE int length() const {
       return size;
     }
@@ -1493,10 +1349,6 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
       size = toStr->Length();
       buf = new uint16_t[size + 1];
       toStr->Write(buf);
-    }
-
-    NAN_DEPRECATED NAN_INLINE int Size() const {
-      return size;
     }
 
     NAN_INLINE int length() const {
@@ -1890,134 +1742,6 @@ NAN_INLINE void NanAsyncQueueWorker (NanAsyncWorker* worker) {
   );
 }
 
-//// Base 64 ////
-
-#define _nan_base64_encoded_size(size) ((size + 2 - ((size + 2) % 3)) / 3 * 4)
-
-// Doesn't check for padding at the end.  Can be 1-2 bytes over.
-NAN_INLINE size_t _nan_base64_decoded_size_fast(size_t size) {
-  size_t remainder = size % 4;
-
-  size = (size / 4) * 3;
-  if (remainder) {
-    if (size == 0 && remainder == 1) {
-      // special case: 1-byte input cannot be decoded
-      size = 0;
-    } else {
-      // non-padded input, add 1 or 2 extra bytes
-      size += 1 + (remainder == 3);
-    }
-  }
-
-  return size;
-}
-
-template<typename T>
-NAN_INLINE size_t _nan_base64_decoded_size(
-    const T* src
-  , size_t size
-) {
-  if (size == 0)
-    return 0;
-
-  if (src[size - 1] == '=')
-    size--;
-  if (size > 0 && src[size - 1] == '=')
-    size--;
-
-  return _nan_base64_decoded_size_fast(size);
-}
-
-// supports regular and URL-safe base64
-static const int _nan_unbase64_table[] = {
-    -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -2, -1, -1, -2, -1, -1
-  , -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1
-  , -2, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, 62, -1, 62, -1, 63
-  , 52, 53, 54, 55, 56, 57, 58, 59, 60, 61, -1, -1, -1, -1, -1, -1
-  , -1,  0,  1,  2,  3,  4,  5,  6,  7,  8,  9, 10, 11, 12, 13, 14
-  , 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, -1, -1, -1, -1, 63
-  , -1, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40
-  , 41, 42, 43, 44, 45, 46, 47, 48, 49, 50, 51, -1, -1, -1, -1, -1
-  , -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1
-  , -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1
-  , -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1
-  , -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1
-  , -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1
-  , -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1
-  , -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1
-  , -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1, -1
-};
-
-#define _nan_unbase64(x) _nan_unbase64_table[(uint8_t)(x)]
-
-template<typename T> static size_t _nan_base64_decode(
-    char* buf
-  , size_t len
-  , const T* src
-  , const size_t srcLen
-) {
-  char* dst = buf;
-  char* dstEnd = buf + len;
-  const T* srcEnd = src + srcLen;
-
-  while (src < srcEnd && dst < dstEnd) {
-    ptrdiff_t remaining = srcEnd - src;
-    char a, b, c, d;
-
-    while (_nan_unbase64(*src) < 0 && src < srcEnd) src++, remaining--;
-    if (remaining == 0 || *src == '=') break;
-    a = _nan_unbase64(*src++);
-
-    while (_nan_unbase64(*src) < 0 && src < srcEnd) src++, remaining--;
-    if (remaining <= 1 || *src == '=') break;
-    b = _nan_unbase64(*src++);
-
-    *dst++ = (a << 2) | ((b & 0x30) >> 4);
-    if (dst == dstEnd) break;
-
-    while (_nan_unbase64(*src) < 0 && src < srcEnd) src++, remaining--;
-    if (remaining <= 2 || *src == '=') break;
-    c = _nan_unbase64(*src++);
-
-    *dst++ = ((b & 0x0F) << 4) | ((c & 0x3C) >> 2);
-    if (dst == dstEnd) break;
-
-    while (_nan_unbase64(*src) < 0 && src < srcEnd) src++, remaining--;
-    if (remaining <= 3 || *src == '=') break;
-    d = _nan_unbase64(*src++);
-
-    *dst++ = ((c & 0x03) << 6) | (d & 0x3F);
-  }
-
-  return dst - buf;
-}
-
-//// HEX ////
-
-template<typename T> unsigned _nan_hex2bin(T c) {
-  if (c >= '0' && c <= '9') return c - '0';
-  if (c >= 'A' && c <= 'F') return 10 + (c - 'A');
-  if (c >= 'a' && c <= 'f') return 10 + (c - 'a');
-  return static_cast<unsigned>(-1);
-}
-
-template<typename T> static size_t _nan_hex_decode(
-    char* buf
-  , size_t len
-  , const T* src
-  , const size_t srcLen
-) {
-  size_t i;
-  for (i = 0; i < len && i * 2 + 1 < srcLen; ++i) {
-    unsigned a = _nan_hex2bin(src[i * 2 + 0]);
-    unsigned b = _nan_hex2bin(src[i * 2 + 1]);
-    if (!~a || !~b) return i;
-    buf[i] = a * 16 + b;
-  }
-
-  return i;
-}
-
 namespace Nan { namespace imp {
 
 inline
@@ -2042,39 +1766,6 @@ IsExternal(v8::Local<v8::String> str) {
 
 }  // end of namespace imp
 }  // end of namespace Nan
-
-static bool _NanGetExternalParts(
-    v8::Handle<v8::Value> val
-  , const char** data
-  , size_t* len
-) {
-  if (node::Buffer::HasInstance(val)) {
-    *data = node::Buffer::Data(val.As<v8::Object>());
-    *len = node::Buffer::Length(val.As<v8::Object>());
-    return true;
-  }
-
-  assert(val->IsString());
-  v8::Local<v8::String> str = NanNew(val.As<v8::String>());
-
-  if (Nan::imp::IsExternal(str)) {
-    const NanExternalOneByteStringResource* ext;
-    ext = Nan::imp::GetExternalResource(str);
-    *data = ext->data();
-    *len = ext->length();
-    return true;
-  }
-
-  if (str->IsExternal()) {
-    const v8::String::ExternalStringResource* ext;
-    ext = str->GetExternalStringResource();
-    *data = reinterpret_cast<const char*>(ext->data());
-    *len = ext->length();
-    return true;
-  }
-
-  return false;
-}
 
 namespace Nan {
   enum Encoding {ASCII, UTF8, BASE64, UCS2, BINARY, HEX, BUFFER};
@@ -2157,178 +1848,6 @@ NAN_INLINE ssize_t NanDecodeWrite(
     , val
     , static_cast<node::encoding>(encoding));
 #endif
-}
-
-/* NAN_DEPRECATED */ NAN_INLINE void* _NanRawString(
-    v8::Handle<v8::Value> from
-  , enum Nan::Encoding encoding
-  , size_t *datalen
-  , void *buf
-  , size_t buflen
-  , int flags
-) {
-  NanScope();
-
-  size_t sz_;
-  size_t term_len = !(flags & v8::String::NO_NULL_TERMINATION);
-  char *data = NULL;
-  size_t len;
-  bool is_extern = _NanGetExternalParts(
-      from
-    , const_cast<const char**>(&data)
-    , &len);
-
-  if (is_extern && !term_len) {
-    Nan::imp::NanSetPointerSafe(datalen, len);
-    return data;
-  }
-
-  v8::Local<v8::String> toStr = from->ToString();
-
-  char *to = static_cast<char *>(buf);
-
-  switch (encoding) {
-    case Nan::ASCII:
-#if NODE_MODULE_VERSION < NODE_0_12_MODULE_VERSION
-      sz_ = toStr->Length();
-      if (to == NULL) {
-        to = new char[sz_ + term_len];
-      } else {
-        assert(buflen >= sz_ + term_len && "too small buffer");
-      }
-      Nan::imp::NanSetPointerSafe<size_t>(
-          datalen
-        , toStr->WriteAscii(to, 0, static_cast<int>(sz_ + term_len), flags));
-      return to;
-#endif
-    case Nan::BINARY:
-    case Nan::BUFFER:
-      sz_ = toStr->Length();
-      if (to == NULL) {
-        to = new char[sz_ + term_len];
-      } else {
-        assert(buflen >= sz_ + term_len && "too small buffer");
-      }
-#if NODE_MODULE_VERSION < NODE_0_12_MODULE_VERSION
-      {
-        uint16_t* twobytebuf = new uint16_t[sz_ + term_len];
-
-        size_t somelen = toStr->Write(twobytebuf, 0,
-          static_cast<int>(sz_ + term_len), flags);
-
-        for (size_t i = 0; i < sz_ + term_len && i < somelen + term_len; i++) {
-          unsigned char *b = reinterpret_cast<unsigned char*>(&twobytebuf[i]);
-          to[i] = *b;
-        }
-
-        Nan::imp::NanSetPointerSafe<size_t>(datalen, somelen);
-
-        delete[] twobytebuf;
-        return to;
-      }
-#else
-      Nan::imp::NanSetPointerSafe<size_t>(
-        datalen,
-        toStr->WriteOneByte(
-            reinterpret_cast<uint8_t *>(to)
-          , 0
-          , static_cast<int>(sz_ + term_len)
-          , flags));
-      return to;
-#endif
-    case Nan::UTF8:
-      sz_ = toStr->Utf8Length();
-      if (to == NULL) {
-        to = new char[sz_ + term_len];
-      } else {
-        assert(buflen >= sz_ + term_len && "too small buffer");
-      }
-      Nan::imp::NanSetPointerSafe<size_t>(
-          datalen
-        , toStr->WriteUtf8(to, static_cast<int>(sz_ + term_len)
-            , NULL, flags)
-          - term_len);
-      return to;
-    case Nan::BASE64:
-      {
-        v8::String::Value value(toStr);
-        sz_ = _nan_base64_decoded_size(*value, value.length());
-        if (to == NULL) {
-          to = new char[sz_ + term_len];
-        } else {
-          assert(buflen >= sz_ + term_len);
-        }
-        Nan::imp::NanSetPointerSafe<size_t>(
-            datalen
-          , _nan_base64_decode(to, sz_, *value, value.length()));
-        if (term_len) {
-          to[sz_] = '\0';
-        }
-        return to;
-      }
-    case Nan::UCS2:
-      {
-        sz_ = toStr->Length();
-        if (to == NULL) {
-          to = new char[(sz_ + term_len) * 2];
-        } else {
-          assert(buflen >= (sz_ + term_len) * 2 && "too small buffer");
-        }
-
-        int bc = 2 * toStr->Write(
-            reinterpret_cast<uint16_t *>(to)
-          , 0
-          , static_cast<int>(sz_ + term_len)
-          , flags);
-        Nan::imp::NanSetPointerSafe<size_t>(datalen, bc);
-        return to;
-      }
-    case Nan::HEX:
-      {
-        v8::String::Value value(toStr);
-        sz_ = value.length();
-        assert(!(sz_ & 1) && "bad hex data");
-        if (to == NULL) {
-          to = new char[sz_ / 2 + term_len];
-        } else {
-          assert(buflen >= sz_ / 2 + term_len && "too small buffer");
-        }
-        Nan::imp::NanSetPointerSafe<size_t>(
-            datalen
-          , _nan_hex_decode(to, sz_ / 2, *value, value.length()));
-      }
-      if (term_len) {
-        to[sz_ / 2] = '\0';
-      }
-      return to;
-    default:
-      assert(0 && "unknown encoding");
-  }
-  return to;
-}
-
-NAN_DEPRECATED NAN_INLINE void* NanRawString(
-    v8::Handle<v8::Value> from
-  , enum Nan::Encoding encoding
-  , size_t *datalen
-  , void *buf
-  , size_t buflen
-  , int flags
-) {
-  return _NanRawString(from, encoding, datalen, buf, buflen, flags);
-}
-
-
-NAN_DEPRECATED NAN_INLINE char* NanCString(
-    v8::Handle<v8::Value> from
-  , size_t *datalen
-  , char *buf = NULL
-  , size_t buflen = 0
-  , int flags = v8::String::NO_OPTIONS
-) {
-    return static_cast<char *>(
-      _NanRawString(from, Nan::UTF8, datalen, buf, buflen, flags)
-    );
 }
 
 NAN_INLINE void NanSetPrototypeTemplate(

--- a/nan.h
+++ b/nan.h
@@ -387,11 +387,6 @@ namespace Nan { namespace imp {
 # define NanReturnNull() return args.GetReturnValue().SetNull()
 # define NanReturnEmptyString() return args.GetReturnValue().SetEmptyString()
 
-  NAN_INLINE
-  v8::Local<v8::Object> NanObjectWrapHandle(const node::ObjectWrap *obj) {
-    return const_cast<node::ObjectWrap*>(obj)->handle();
-  }
-
   NAN_INLINE v8::Local<v8::Primitive> NanUndefined() {
     NanEscapableScope();
     return NanEscapeScope(NanNew(v8::Undefined(v8::Isolate::GetCurrent())));
@@ -795,11 +790,6 @@ namespace Nan { namespace imp {
 # define NanReturnUndefined() return v8::Undefined()
 # define NanReturnNull() return v8::Null()
 # define NanReturnEmptyString() return v8::String::Empty()
-
-  NAN_INLINE
-  v8::Local<v8::Object> NanObjectWrapHandle(const node::ObjectWrap *obj) {
-    return v8::Local<v8::Object>::New(obj->handle_);
-  }
 
   NAN_INLINE v8::Local<v8::Primitive> NanUndefined() {
     NanEscapableScope();
@@ -1684,6 +1674,16 @@ NAN_INLINE void NanSetInstanceTemplate(
 ) {
   NanSetTemplate(templ->InstanceTemplate(), name, value, attributes);
 }
+
+//=== ObjectWrap ===============================================================
+
+class NanObjectWrap : public node::ObjectWrap {
+#if NODE_MODULE_VERSION < NODE_0_12_MODULE_VERSION
+ public:
+  inline v8::Local<v8::Object> handle() { return NanNew(handle_); }
+  inline v8::Persistent<v8::Object> &persistent() { return handle_; }
+#endif
+};
 
 //=== Weak Persistent Handling =================================================
 

--- a/nan.h
+++ b/nan.h
@@ -267,9 +267,8 @@ namespace Nan { namespace imp {
 }  // end of namespace imp
 }  // end of namespace Nan
 
-/* io.js 1.0  */
-#if NODE_MODULE_VERSION >= IOJS_1_0_MODULE_VERSION \
-  || NODE_VERSION_AT_LEAST(0, 11, 15)
+/* node 0.12  */
+#if NODE_MODULE_VERSION >= NODE_0_12_MODULE_VERSION
   NAN_INLINE
   void NanSetCounterFunction(v8::CounterLookupCallback cb) {
     v8::Isolate::GetCurrent()->SetCounterFunction(cb);
@@ -1746,7 +1745,7 @@ namespace Nan {
   enum Encoding {ASCII, UTF8, BASE64, UCS2, BINARY, HEX, BUFFER};
 }
 
-#if !NODE_VERSION_AT_LEAST(0, 10, 0)
+#if NODE_MODULE_VERSION < NODE_0_10_MODULE_VERSION
 # include "nan_string_bytes.h"  // NOLINT(build/include)
 #endif
 
@@ -1774,7 +1773,7 @@ NAN_INLINE v8::Local<v8::Value> NanEncode(
     , buf, len
     , static_cast<node::encoding>(encoding));
 #else
-# if NODE_VERSION_AT_LEAST(0, 10, 0)
+# if NODE_MODULE_VERSION >= NODE_0_10_MODULE_VERSION
   return node::Encode(buf, len, static_cast<node::encoding>(encoding));
 # else
   return Nan::imp::Encode(reinterpret_cast<const char*>(buf), len, encoding);

--- a/nan.h
+++ b/nan.h
@@ -267,6 +267,55 @@ namespace Nan { namespace imp {
 }  // end of namespace imp
 }  // end of namespace Nan
 
+//=== HandleScope ==============================================================
+
+class NanScope {
+  v8::HandleScope scope;
+
+ public:
+#if NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION
+  inline static int NumberOfHandles() {
+    return v8::HandleScope::NumberOfHandles(v8::Isolate::GetCurrent());
+  }
+  inline NanScope() : scope(v8::Isolate::GetCurrent()) {}
+#else
+  inline static int NumberOfHandles() {
+    return v8::HandleScope::NumberOfHandles();
+  }
+#endif
+};
+
+class NanEscapableScope {
+ public:
+#if NODE_MODULE_VERSION > NODE_0_10_MODULE_VERSION
+  inline static int NumberOfHandles() {
+    return v8::EscapableHandleScope::NumberOfHandles(v8::Isolate::GetCurrent());
+  }
+
+  inline NanEscapableScope() : scope(v8::Isolate::GetCurrent()) {}
+
+  template<typename T>
+  inline v8::Local<T> Escape(v8::Local<T> value) {
+    return scope.Escape(value);
+  }
+
+ private:
+  v8::EscapableHandleScope scope;
+#else
+  inline static int NumberOfHandles() {
+    return v8::HandleScope::NumberOfHandles();
+  }
+
+  template<typename T>
+  inline v8::Local<T> Escape(v8::Local<T> value) {
+    return scope.Close(value);
+  }
+
+ private:
+  v8::HandleScope scope;
+#endif
+};
+
 /* node 0.12  */
 #if NODE_MODULE_VERSION >= NODE_0_12_MODULE_VERSION
   NAN_INLINE
@@ -372,11 +421,6 @@ namespace Nan { namespace imp {
       NAN_INDEX_QUERY_ARGS_TYPE;
   typedef void NAN_INDEX_QUERY_RETURN_TYPE;
 
-# define NanScope() v8::HandleScope scope(v8::Isolate::GetCurrent())
-# define NanEscapableScope()                                                   \
-  v8::EscapableHandleScope scope(v8::Isolate::GetCurrent())
-
-# define NanEscapeScope(val) scope.Escape(Nan::imp::NanEnsureLocal(val))
 # define NanLocker() v8::Locker locker(v8::Isolate::GetCurrent())
 # define NanUnlocker() v8::Unlocker unlocker(v8::Isolate::GetCurrent())
 # define NanReturnValue(value)                                                 \
@@ -388,23 +432,23 @@ namespace Nan { namespace imp {
 # define NanReturnEmptyString() return args.GetReturnValue().SetEmptyString()
 
   NAN_INLINE v8::Local<v8::Primitive> NanUndefined() {
-    NanEscapableScope();
-    return NanEscapeScope(NanNew(v8::Undefined(v8::Isolate::GetCurrent())));
+    NanEscapableScope scope;
+    return scope.Escape(NanNew(v8::Undefined(v8::Isolate::GetCurrent())));
   }
 
   NAN_INLINE v8::Local<v8::Primitive> NanNull() {
-    NanEscapableScope();
-    return NanEscapeScope(NanNew(v8::Null(v8::Isolate::GetCurrent())));
+    NanEscapableScope scope;
+    return scope.Escape(NanNew(v8::Null(v8::Isolate::GetCurrent())));
   }
 
   NAN_INLINE v8::Local<v8::Boolean> NanTrue() {
-    NanEscapableScope();
-    return NanEscapeScope(NanNew(v8::True(v8::Isolate::GetCurrent())));
+    NanEscapableScope scope;
+    return scope.Escape(NanNew(v8::True(v8::Isolate::GetCurrent())));
   }
 
   NAN_INLINE v8::Local<v8::Boolean> NanFalse() {
-    NanEscapableScope();
-    return NanEscapeScope(NanNew(v8::False(v8::Isolate::GetCurrent())));
+    NanEscapableScope scope;
+    return scope.Escape(NanNew(v8::False(v8::Isolate::GetCurrent())));
   }
 
   NAN_INLINE int NanAdjustExternalMemory(int bc) {
@@ -492,7 +536,7 @@ namespace Nan { namespace imp {
 
 # define _NAN_THROW_ERROR(fun, errmsg)                                         \
     do {                                                                       \
-      NanScope();                                                              \
+      NanScope scope;                                                          \
       v8::Isolate::GetCurrent()->ThrowException(_NAN_ERROR(fun, errmsg));      \
     } while (0);
 
@@ -505,7 +549,7 @@ namespace Nan { namespace imp {
   }
 
   NAN_INLINE void NanThrowError(v8::Handle<v8::Value> error) {
-    NanScope();
+    NanScope scope;
     v8::Isolate::GetCurrent()->ThrowException(error);
   }
 
@@ -778,9 +822,6 @@ namespace Nan { namespace imp {
   typedef const v8::AccessorInfo& NAN_INDEX_QUERY_ARGS_TYPE;
   typedef v8::Handle<v8::Integer> NAN_INDEX_QUERY_RETURN_TYPE;
 
-# define NanScope() v8::HandleScope scope
-# define NanEscapableScope() v8::HandleScope scope
-# define NanEscapeScope(val) scope.Close(val)
 # define NanLocker() v8::Locker locker
 # define NanUnlocker() v8::Unlocker unlocker
 # define NanReturnValue(value)                                                 \
@@ -792,23 +833,23 @@ namespace Nan { namespace imp {
 # define NanReturnEmptyString() return v8::String::Empty()
 
   NAN_INLINE v8::Local<v8::Primitive> NanUndefined() {
-    NanEscapableScope();
-    return NanEscapeScope(NanNew(v8::Undefined()));
+    NanEscapableScope scope;
+    return scope.Escape(NanNew(v8::Undefined()));
   }
 
   NAN_INLINE v8::Local<v8::Primitive> NanNull() {
-    NanEscapableScope();
-    return NanEscapeScope(NanNew(v8::Null()));
+    NanEscapableScope scope;
+    return scope.Escape(NanNew(v8::Null()));
   }
 
   NAN_INLINE v8::Local<v8::Boolean> NanTrue() {
-    NanEscapableScope();
-    return NanEscapeScope(NanNew(v8::True()));
+    NanEscapableScope scope;
+    return scope.Escape(NanNew(v8::True()));
   }
 
   NAN_INLINE v8::Local<v8::Boolean> NanFalse() {
-    NanEscapableScope();
-    return NanEscapeScope(NanNew(v8::False()));
+    NanEscapableScope scope;
+    return scope.Escape(NanNew(v8::False()));
   }
 
   NAN_INLINE int NanAdjustExternalMemory(int bc) {
@@ -886,7 +927,7 @@ namespace Nan { namespace imp {
 
 # define _NAN_THROW_ERROR(fun, errmsg)                                         \
     do {                                                                       \
-      NanScope();                                                              \
+      NanScope scope;                                                          \
       return v8::Local<v8::Value>::New(                                        \
         v8::ThrowException(_NAN_ERROR(fun, errmsg)));                          \
     } while (0);
@@ -902,7 +943,7 @@ namespace Nan { namespace imp {
   NAN_INLINE v8::Local<v8::Value> NanThrowError(
       v8::Handle<v8::Value> error
   ) {
-    NanScope();
+    NanScope scope;
     return v8::Local<v8::Value>::New(v8::ThrowException(error));
   }
 
@@ -1197,13 +1238,13 @@ typedef void (*NanFreeCallback)(char *data, void *hint);
 class NanCallback {
  public:
   NanCallback() {
-    NanScope();
+    NanScope scope;
     v8::Local<v8::Object> obj = NanNew<v8::Object>();
     NanAssignPersistent(handle, obj);
   }
 
   explicit NanCallback(const v8::Handle<v8::Function> &fn) {
-    NanScope();
+    NanScope scope;
     v8::Local<v8::Object> obj = NanNew<v8::Object>();
     NanAssignPersistent(handle, obj);
     SetFunction(fn);
@@ -1215,7 +1256,7 @@ class NanCallback {
   }
 
   bool operator==(const NanCallback &other) const {
-    NanScope();
+    NanScope scope;
     v8::Local<v8::Value> a = NanNew(handle)->Get(kCallbackIndex);
     v8::Local<v8::Value> b = NanNew(other.handle)->Get(kCallbackIndex);
     return a->StrictEquals(b);
@@ -1226,18 +1267,18 @@ class NanCallback {
   }
 
   NAN_INLINE void SetFunction(const v8::Handle<v8::Function> &fn) {
-    NanScope();
+    NanScope scope;
     NanNew(handle)->Set(kCallbackIndex, fn);
   }
 
   NAN_INLINE v8::Local<v8::Function> GetFunction() const {
-    NanEscapableScope();
-    return NanEscapeScope(NanNew(handle)->Get(kCallbackIndex)
+    NanEscapableScope scope;
+    return scope.Escape(NanNew(handle)->Get(kCallbackIndex)
         .As<v8::Function>());
   }
 
   NAN_INLINE bool IsEmpty() const {
-    NanScope();
+    NanScope scope;
     return NanNew(handle)->Get(kCallbackIndex)->IsUndefined();
   }
 
@@ -1273,32 +1314,32 @@ class NanCallback {
                            , v8::Handle<v8::Object> target
                            , int argc
                            , v8::Handle<v8::Value> argv[]) const {
-    NanEscapableScope();
+    NanEscapableScope scope;
 
     v8::Local<v8::Function> callback = NanNew(handle)->
         Get(kCallbackIndex).As<v8::Function>();
-    return NanEscapeScope(node::MakeCallback(
+    return scope.Escape(Nan::imp::NanEnsureLocal(node::MakeCallback(
         isolate
       , target
       , callback
       , argc
       , argv
-    ));
+    )));
   }
 #else
   v8::Handle<v8::Value> Call_(v8::Handle<v8::Object> target
                            , int argc
                            , v8::Handle<v8::Value> argv[]) const {
-    NanEscapableScope();
+    NanEscapableScope scope;
 
     v8::Local<v8::Function> callback = handle->
         Get(kCallbackIndex).As<v8::Function>();
-    return NanEscapeScope(node::MakeCallback(
+    return scope.Escape(Nan::imp::NanEnsureLocal(node::MakeCallback(
         target
       , callback
       , argc
       , argv
-    ));
+    )));
   }
 #endif
 };
@@ -1309,13 +1350,13 @@ class NanCallback {
       : callback(callback_), errmsg_(NULL) {
     request.data = this;
 
-    NanScope();
+    NanScope scope;
     v8::Local<v8::Object> obj = NanNew<v8::Object>();
     NanAssignPersistent(persistentHandle, obj);
   }
 
   virtual ~NanAsyncWorker() {
-    NanScope();
+    NanScope scope;
 
     if (!persistentHandle.IsEmpty())
       NanDisposePersistent(persistentHandle);
@@ -1326,7 +1367,7 @@ class NanCallback {
   }
 
   virtual void WorkComplete() {
-    NanScope();
+    NanScope scope;
 
     if (errmsg_ == NULL)
       HandleOKCallback();
@@ -1338,36 +1379,36 @@ class NanCallback {
 
   NAN_INLINE void SaveToPersistent(
       const char *key, const v8::Local<v8::Value> &value) {
-    NanScope();
+    NanScope scope;
     NanNew(persistentHandle)->Set(NanNew(key), value);
   }
 
   NAN_INLINE void SaveToPersistent(
       const v8::Handle<v8::String> &key, const v8::Local<v8::Value> &value) {
-    NanScope();
+    NanScope scope;
     NanNew(persistentHandle)->Set(key, value);
   }
 
   NAN_INLINE void SaveToPersistent(
       uint32_t index, const v8::Local<v8::Value> &value) {
-    NanScope();
+    NanScope scope;
     NanNew(persistentHandle)->Set(index, value);
   }
 
   NAN_INLINE v8::Local<v8::Value> GetFromPersistent(const char *key) const {
-    NanEscapableScope();
-    return NanEscapeScope(NanNew(persistentHandle)->Get(NanNew(key)));
+    NanEscapableScope scope;
+    return scope.Escape(NanNew(persistentHandle)->Get(NanNew(key)));
   }
 
   NAN_INLINE v8::Local<v8::Value>
   GetFromPersistent(const v8::Local<v8::String> &key) const {
-    NanEscapableScope();
-    return NanEscapeScope(NanNew(persistentHandle)->Get(key));
+    NanEscapableScope scope;
+    return scope.Escape(NanNew(persistentHandle)->Get(key));
   }
 
   NAN_INLINE v8::Local<v8::Value> GetFromPersistent(uint32_t index) const {
-    NanEscapableScope();
-    return NanEscapeScope(NanNew(persistentHandle)->Get(index));
+    NanEscapableScope scope;
+    return scope.Escape(NanNew(persistentHandle)->Get(index));
   }
 
   virtual void Execute() = 0;
@@ -1387,7 +1428,7 @@ class NanCallback {
   }
 
   virtual void HandleErrorCallback() {
-    NanScope();
+    NanScope scope;
 
     v8::Local<v8::Value> argv[] = {
         v8::Exception::Error(NanNew<v8::String>(ErrorMessage()))

--- a/nan.h
+++ b/nan.h
@@ -1568,15 +1568,15 @@ class NanCallback {
   }
 
   NAN_INLINE void SaveToPersistent(
-      const char *key, const v8::Local<v8::Object> &obj) {
+      const char *key, const v8::Local<v8::Value> &value) {
     v8::Local<v8::Object> handle = NanNew(persistentHandle);
-    handle->Set(NanNew<v8::String>(key), obj);
+    handle->Set(NanNew<v8::String>(key), value);
   }
 
-  v8::Local<v8::Object> GetFromPersistent(const char *key) const {
+  v8::Local<v8::Value> GetFromPersistent(const char *key) const {
     NanEscapableScope();
     v8::Local<v8::Object> handle = NanNew(persistentHandle);
-    return NanEscapeScope(handle->Get(NanNew(key)).As<v8::Object>());
+    return NanEscapeScope(handle->Get(NanNew(key)));
   }
 
   virtual void Execute() = 0;

--- a/nan.h
+++ b/nan.h
@@ -316,6 +316,26 @@ class NanEscapableScope {
 #endif
 };
 
+//=== Locker ===================================================================
+
+class NanLocker {
+ private:
+  v8::Locker locker;
+
+ public:
+  explicit inline NanLocker(v8::Isolate *isolate) : locker(isolate) {}
+
+  inline static bool IsLocked(v8::Isolate *isolate) {
+    return v8::Locker::IsLocked(isolate);
+  }
+
+  inline static bool IsActive() { return v8::Locker::IsActive(); }
+};
+
+//=== Unlocker =================================================================
+
+class NanUnlocker : public v8::Unlocker {};
+
 /* node 0.12  */
 #if NODE_MODULE_VERSION >= NODE_0_12_MODULE_VERSION
   NAN_INLINE
@@ -421,8 +441,6 @@ class NanEscapableScope {
       NAN_INDEX_QUERY_ARGS_TYPE;
   typedef void NAN_INDEX_QUERY_RETURN_TYPE;
 
-# define NanLocker() v8::Locker locker(v8::Isolate::GetCurrent())
-# define NanUnlocker() v8::Unlocker unlocker(v8::Isolate::GetCurrent())
 # define NanReturnValue(value)                                                 \
   return args.GetReturnValue().Set(Nan::imp::NanEnsureHandleOrPersistent(value))
 # define NanReturnUndefined() return
@@ -822,8 +840,6 @@ class NanEscapableScope {
   typedef const v8::AccessorInfo& NAN_INDEX_QUERY_ARGS_TYPE;
   typedef v8::Handle<v8::Integer> NAN_INDEX_QUERY_RETURN_TYPE;
 
-# define NanLocker() v8::Locker locker
-# define NanUnlocker() v8::Unlocker unlocker
 # define NanReturnValue(value)                                                 \
     return Nan::imp::NanEnsureHandleOrPersistent(value)
 # define NanReturnHolder() NanReturnValue(args.Holder())

--- a/nan.h
+++ b/nan.h
@@ -789,7 +789,7 @@ namespace Nan { namespace imp {
 # define NanLocker() v8::Locker locker
 # define NanUnlocker() v8::Unlocker unlocker
 # define NanReturnValue(value)                                                 \
-    return scope.Close(Nan::imp::NanEnsureHandleOrPersistent(value))
+    return Nan::imp::NanEnsureHandleOrPersistent(value)
 # define NanReturnHolder() NanReturnValue(args.Holder())
 # define NanReturnThis() NanReturnValue(args.This())
 # define NanReturnUndefined() return v8::Undefined()

--- a/nan.h
+++ b/nan.h
@@ -1353,17 +1353,29 @@ class NanCallback {
   }
 
   NAN_INLINE void SaveToPersistent(
+      const v8::Handle<v8::String> &key, const v8::Local<v8::Value> &value) {
+    NanScope();
+    NanNew(persistentHandle)->Set(key, value);
+  }
+
+  NAN_INLINE void SaveToPersistent(
       uint32_t index, const v8::Local<v8::Value> &value) {
     NanScope();
     NanNew(persistentHandle)->Set(index, value);
   }
 
-  v8::Local<v8::Value> GetFromPersistent(const char *key) const {
+  NAN_INLINE v8::Local<v8::Value> GetFromPersistent(const char *key) const {
     NanEscapableScope();
     return NanEscapeScope(NanNew(persistentHandle)->Get(NanNew(key)));
   }
 
-  v8::Local<v8::Value> GetFromPersistent(uint32_t index) const {
+  NAN_INLINE v8::Local<v8::Value>
+  GetFromPersistent(const v8::Local<v8::String> &key) const {
+    NanEscapableScope();
+    return NanEscapeScope(NanNew(persistentHandle)->Get(key));
+  }
+
+  NAN_INLINE v8::Local<v8::Value> GetFromPersistent(uint32_t index) const {
     NanEscapableScope();
     return NanEscapeScope(NanNew(persistentHandle)->Get(index));
   }

--- a/nan.h
+++ b/nan.h
@@ -511,86 +511,6 @@ return args.GetReturnValue().Set(Nan::imp::NanEnsureHandleOrPersistent(value))
       handle.Reset(v8::Isolate::GetCurrent(), obj);
   }
 
-  template<typename T, typename P>
-  class _NanWeakCallbackData;
-
-  template<typename T, typename P>
-  struct _NanWeakCallbackInfo {
-    typedef void (*Callback)(const _NanWeakCallbackData<T, P>& data);
-    NAN_INLINE _NanWeakCallbackInfo(v8::Handle<T> handle, P* param, Callback cb)
-      : parameter(param), callback(cb) {
-       NanAssignPersistent(persistent, handle);
-    }
-
-    NAN_INLINE ~_NanWeakCallbackInfo() {
-      persistent.Reset();
-    }
-
-    P* const parameter;
-    Callback const callback;
-    v8::Persistent<T> persistent;
-
-   private:
-    NAN_DISALLOW_ASSIGN_COPY_MOVE(_NanWeakCallbackInfo)
-  };
-
-  template<typename T, typename P>
-  class _NanWeakCallbackData {
-   public:
-    NAN_INLINE _NanWeakCallbackData(_NanWeakCallbackInfo<T, P> *info)
-      : info_(info) { }
-
-    NAN_INLINE v8::Local<T> GetValue() const {
-      return NanNew(info_->persistent);
-    }
-
-    NAN_INLINE P* GetParameter() const { return info_->parameter; }
-
-    NAN_INLINE bool IsNearDeath() const {
-      return info_->persistent.IsNearDeath();
-    }
-
-    NAN_INLINE void Revive() const;
-
-    NAN_INLINE _NanWeakCallbackInfo<T, P>* GetCallbackInfo() const {
-      return info_;
-    }
-
-   private:
-    _NanWeakCallbackInfo<T, P>* info_;
-  };
-
-  template<typename T, typename P>
-  static void _NanWeakCallbackDispatcher(
-    const v8::WeakCallbackData<T, _NanWeakCallbackInfo<T, P> > &data) {
-      _NanWeakCallbackInfo<T, P> *info = data.GetParameter();
-      _NanWeakCallbackData<T, P> wcbd(info);
-      info->callback(wcbd);
-      if (wcbd.IsNearDeath()) {
-        delete wcbd.GetCallbackInfo();
-      }
-  }
-
-  template<typename T, typename P>
-  NAN_INLINE void _NanWeakCallbackData<T, P>::Revive() const {
-      info_->persistent.SetWeak(info_, &_NanWeakCallbackDispatcher<T, P>);
-  }
-
-template<typename T, typename P>
-NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
-    v8::Handle<T> handle
-  , P* parameter
-  , typename _NanWeakCallbackInfo<T, P>::Callback callback) {
-    _NanWeakCallbackInfo<T, P> *cbinfo =
-     new _NanWeakCallbackInfo<T, P>(handle, parameter, callback);
-    cbinfo->persistent.SetWeak(cbinfo, &_NanWeakCallbackDispatcher<T, P>);
-    return cbinfo;
-}
-
-# define NAN_WEAK_CALLBACK(name)                                               \
-    template<typename T, typename P>                                           \
-    static void name(const _NanWeakCallbackData<T, P> &data)
-
 # define _NAN_ERROR(fun, errmsg) fun(NanNew<v8::String>(errmsg))
 
 # define _NAN_THROW_ERROR(fun, errmsg)                                         \
@@ -1003,93 +923,6 @@ NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
       handle.Dispose();
       handle = v8::Persistent<T>::New(obj);
   }
-
-  template<typename T, typename P>
-  class _NanWeakCallbackData;
-
-  template<typename T, typename P>
-  struct _NanWeakCallbackInfo {
-    typedef void (*Callback)(const _NanWeakCallbackData<T, P> &data);
-    NAN_INLINE _NanWeakCallbackInfo(v8::Handle<T> handle, P* param, Callback cb)
-      : parameter(param)
-      , callback(cb)
-      , persistent(v8::Persistent<T>::New(handle)) { }
-
-    NAN_INLINE ~_NanWeakCallbackInfo() {
-      persistent.Dispose();
-      persistent.Clear();
-    }
-
-    P* const parameter;
-    Callback const callback;
-    v8::Persistent<T> persistent;
-
-   private:
-    NAN_DISALLOW_ASSIGN_COPY_MOVE(_NanWeakCallbackInfo)
-  };
-
-  template<typename T, typename P>
-  class _NanWeakCallbackData {
-   public:
-    NAN_INLINE _NanWeakCallbackData(_NanWeakCallbackInfo<T, P> *info)
-      : info_(info) { }
-
-    NAN_INLINE v8::Local<T> GetValue() const {
-      return NanNew(info_->persistent);
-    }
-
-    NAN_INLINE P* GetParameter() const { return info_->parameter; }
-
-    NAN_INLINE bool IsNearDeath() const {
-      return info_->persistent.IsNearDeath();
-    }
-
-    NAN_INLINE void Revive() const;
-
-    NAN_INLINE _NanWeakCallbackInfo<T, P>* GetCallbackInfo() const {
-      return info_;
-    }
-
-   private:
-    _NanWeakCallbackInfo<T, P>* info_;
-  };
-
-  template<typename T, typename P>
-  static void _NanWeakPersistentDispatcher(
-      v8::Persistent<v8::Value> object, void *data) {
-    (void) object;  // unused
-    _NanWeakCallbackInfo<T, P>* info =
-        static_cast<_NanWeakCallbackInfo<T, P>*>(data);
-    _NanWeakCallbackData<T, P> wcbd(info);
-    info->callback(wcbd);
-    if (wcbd.IsNearDeath()) {
-      delete wcbd.GetCallbackInfo();
-    }
-  }
-
-  template<typename T, typename P>
-  NAN_INLINE void _NanWeakCallbackData<T, P>::Revive() const {
-      info_->persistent.MakeWeak(
-          info_
-        , &_NanWeakPersistentDispatcher<T, P>);
-  }
-
-  template<typename T, typename P>
-  NAN_INLINE _NanWeakCallbackInfo<T, P>* NanMakeWeakPersistent(
-    v8::Handle<T> handle
-  , P* parameter
-  , typename _NanWeakCallbackInfo<T, P>::Callback callback) {
-      _NanWeakCallbackInfo<T, P> *cbinfo =
-        new _NanWeakCallbackInfo<T, P>(handle, parameter, callback);
-      cbinfo->persistent.MakeWeak(
-          cbinfo
-        , &_NanWeakPersistentDispatcher<T, P>);
-      return cbinfo;
-  }
-
-# define NAN_WEAK_CALLBACK(name)                                               \
-    template<typename T, typename P>                                           \
-    static void name(const _NanWeakCallbackData<T, P> &data)
 
 # define _NAN_ERROR(fun, errmsg)                                               \
     fun(v8::String::New(errmsg))
@@ -1866,6 +1699,111 @@ NAN_INLINE void NanSetInstanceTemplate(
   , v8::PropertyAttribute attributes
 ) {
   NanSetTemplate(templ->InstanceTemplate(), name, value, attributes);
+}
+
+//=== Weak Persistent Handling =================================================
+
+#if NODE_MODULE_VERSION >= NODE_0_12_MODULE_VERSION
+# define NAN_WEAK_CALLBACK_DATA_TYPE_ \
+    v8::WeakCallbackData<T, NanWeakCallbackData<T, P> > const&
+# define NAN_WEAK_CALLBACK_SIG_ NAN_WEAK_CALLBACK_DATA_TYPE_
+#else
+# define NAN_WEAK_CALLBACK_DATA_TYPE_ void *
+# define NAN_WEAK_CALLBACK_SIG_ \
+    v8::Persistent<v8::Value>, NAN_WEAK_CALLBACK_DATA_TYPE_
+#endif
+
+template <typename T, typename P>
+class NanWeakCallbackData {
+ public:  // constructors
+  typedef void (*Callback)(
+      NanWeakCallbackData & data  // NOLINT(runtime/references)
+      );
+  NanWeakCallbackData(v8::Handle<T> handle, P* param, Callback cb)
+    : parameter(param), callback(cb) {
+    NanAssignPersistent(persistent, handle);
+    Revive();
+  }
+  inline ~NanWeakCallbackData();
+
+ public:  // member functions
+  v8::Local<T> GetValue() const { return NanNew(persistent); }
+  v8::Persistent<T> &GetPersistent() const { return persistent; }
+  P* GetParameter() const { return parameter; }
+  bool IsNearDeath() const { return persistent.IsNearDeath(); }
+  inline void Revive();
+
+ private:  // constructors
+  NAN_DISALLOW_ASSIGN_COPY_MOVE(NanWeakCallbackData)
+
+ private:  // static member functions
+  static
+  void
+  invoke(NAN_WEAK_CALLBACK_SIG_ data) {
+    NanWeakCallbackData * wcbd = unwrap(data);
+    wcbd->callback(*wcbd);
+    if (wcbd->IsNearDeath()) {
+      delete wcbd;
+    }
+  }
+
+  static inline
+  NanWeakCallbackData *
+  unwrap(NAN_WEAK_CALLBACK_DATA_TYPE_ data);
+
+ private:  // data members
+  P* const parameter;
+  Callback const callback;
+  v8::Persistent<T> persistent;
+};
+
+#undef NAN_WEAK_CALLBACK_DATA_TYPE_
+#undef NAN_WEAK_CALLBACK_SIG_
+
+#if NODE_MODULE_VERSION >= NODE_0_12_MODULE_VERSION
+
+template <typename T, typename P>
+NanWeakCallbackData<T, P>::~NanWeakCallbackData() { persistent.Reset(); }
+
+template <typename T, typename P>
+void
+NanWeakCallbackData<T, P>::Revive() { persistent.SetWeak(this, &invoke); }
+
+template <typename T, typename P>
+NanWeakCallbackData<T, P> *
+NanWeakCallbackData<T, P>::unwrap(
+    v8::WeakCallbackData<T, NanWeakCallbackData> const& data) {
+  return data.GetParameter();
+}
+
+#else
+
+template <typename T, typename P>
+NanWeakCallbackData<T, P>::~NanWeakCallbackData() {
+  persistent.Dispose();
+  persistent.Clear();
+}
+
+template <typename T, typename P>
+void
+NanWeakCallbackData<T, P>::Revive() { persistent.MakeWeak(this, &invoke); }
+
+template <typename T, typename P>
+NanWeakCallbackData<T, P> *
+NanWeakCallbackData<T, P>::unwrap(void * data) {
+  return static_cast<NanWeakCallbackData*>(data);
+}
+
+#endif
+
+template<typename T, typename P>
+inline
+NanWeakCallbackData<T, P>*
+NanMakeWeakPersistent(
+    v8::Handle<T> handle
+  , P* parameter
+  , typename NanWeakCallbackData<T, P>::Callback callback) {
+  return new NanWeakCallbackData<T, P>(handle, parameter, callback);
 }
 
 //=== Export ==================================================================

--- a/nan.h
+++ b/nan.h
@@ -1543,14 +1543,24 @@ class NanCallback {
 
   NAN_INLINE void SaveToPersistent(
       const char *key, const v8::Local<v8::Value> &value) {
-    v8::Local<v8::Object> handle = NanNew(persistentHandle);
-    handle->Set(NanNew<v8::String>(key), value);
+    NanScope();
+    NanNew(persistentHandle)->Set(NanNew(key), value);
+  }
+
+  NAN_INLINE void SaveToPersistent(
+      uint32_t index, const v8::Local<v8::Value> &value) {
+    NanScope();
+    NanNew(persistentHandle)->Set(index, value);
   }
 
   v8::Local<v8::Value> GetFromPersistent(const char *key) const {
     NanEscapableScope();
-    v8::Local<v8::Object> handle = NanNew(persistentHandle);
-    return NanEscapeScope(handle->Get(NanNew(key)));
+    return NanEscapeScope(NanNew(persistentHandle)->Get(NanNew(key)));
+  }
+
+  v8::Local<v8::Value> GetFromPersistent(uint32_t index) const {
+    NanEscapableScope();
+    return NanEscapeScope(NanNew(persistentHandle)->Get(index));
   }
 
   virtual void Execute() = 0;

--- a/test/cpp/asyncprogressworker.cpp
+++ b/test/cpp/asyncprogressworker.cpp
@@ -46,7 +46,6 @@ class ProgressWorker : public NanAsyncProgressWorker {
 };
 
 NAN_METHOD(DoProgress) {
-  NanScope();
   NanCallback *progress = new NanCallback(args[2].As<v8::Function>());
   NanCallback *callback = new NanCallback(args[3].As<v8::Function>());
   NanAsyncQueueWorker(new ProgressWorker(

--- a/test/cpp/asyncprogressworker.cpp
+++ b/test/cpp/asyncprogressworker.cpp
@@ -31,7 +31,7 @@ class ProgressWorker : public NanAsyncProgressWorker {
   }
 
   void HandleProgressCallback(const char *data, size_t size) {
-    NanScope();
+    NanScope scope;
 
     v8::Local<v8::Value> argv[] = {
         NanNew<v8::Integer>(*reinterpret_cast<int*>(const_cast<char*>(data)))

--- a/test/cpp/asyncworker.cpp
+++ b/test/cpp/asyncworker.cpp
@@ -27,7 +27,6 @@ class SleepWorker : public NanAsyncWorker {
 };
 
 NAN_METHOD(DoSleep) {
-  NanScope();
   NanCallback *callback = new NanCallback(args[1].As<v8::Function>());
   NanAsyncQueueWorker(new SleepWorker(callback, args[0]->Uint32Value()));
   NanReturnUndefined();

--- a/test/cpp/asyncworkererror.cpp
+++ b/test/cpp/asyncworkererror.cpp
@@ -19,7 +19,6 @@ class ErrorWorker : public NanAsyncWorker {
 };
 
 NAN_METHOD(Work) {
-  NanScope();
   NanCallback *callback = new NanCallback(args[0].As<v8::Function>());
   NanAsyncQueueWorker(new ErrorWorker(callback));
   NanReturnUndefined();

--- a/test/cpp/bufferworkerpersistent.cpp
+++ b/test/cpp/bufferworkerpersistent.cpp
@@ -23,7 +23,10 @@ class BufferWorker : public NanAsyncWorker {
 
       NanScope();
 
+     /* test them all */
       SaveToPersistent("buffer", bufferHandle);
+      SaveToPersistent(NanNew("puffer"), bufferHandle);
+      SaveToPersistent(0u, bufferHandle);
     }
 
   ~BufferWorker() {}
@@ -36,6 +39,12 @@ class BufferWorker : public NanAsyncWorker {
     NanScope();
 
     v8::Local<v8::Value> handle = GetFromPersistent("buffer");
+    callback->Call(1, &handle);
+
+    handle = GetFromPersistent(NanNew("puffer"));
+    callback->Call(1, &handle);
+
+    handle = GetFromPersistent(0u);
     callback->Call(1, &handle);
   }
 

--- a/test/cpp/bufferworkerpersistent.cpp
+++ b/test/cpp/bufferworkerpersistent.cpp
@@ -35,9 +35,8 @@ class BufferWorker : public NanAsyncWorker {
   void HandleOKCallback () {
     NanScope();
 
-    v8::Local<v8::Object> handle = GetFromPersistent("buffer");
-    v8::Local<v8::Value> argv[] = { handle };
-    callback->Call(1, argv);
+    v8::Local<v8::Value> handle = GetFromPersistent("buffer");
+    callback->Call(1, &handle);
   }
 
  private:

--- a/test/cpp/bufferworkerpersistent.cpp
+++ b/test/cpp/bufferworkerpersistent.cpp
@@ -35,7 +35,7 @@ class BufferWorker : public NanAsyncWorker {
   }
 
   void HandleOKCallback () {
-    NanScope();
+    NanScope scope;
 
     v8::Local<v8::Value> handle = GetFromPersistent("buffer");
     callback->Call(1, &handle);

--- a/test/cpp/bufferworkerpersistent.cpp
+++ b/test/cpp/bufferworkerpersistent.cpp
@@ -20,7 +20,6 @@ class BufferWorker : public NanAsyncWorker {
         , v8::Local<v8::Object> &bufferHandle
       )
     : NanAsyncWorker(callback), milliseconds(milliseconds) {
-
       NanScope();
 
      /* test them all */
@@ -53,7 +52,6 @@ class BufferWorker : public NanAsyncWorker {
 };
 
 NAN_METHOD(DoSleep) {
-  NanScope();
   v8::Local<v8::Object> bufferHandle = args[1].As<v8::Object>();
   NanCallback *callback = new NanCallback(args[2].As<v8::Function>());
   assert(!callback->IsEmpty() && "Callback shoud not be empty");

--- a/test/cpp/gc.cpp
+++ b/test/cpp/gc.cpp
@@ -21,7 +21,6 @@ NAN_GC_CALLBACK(gcEpilogueCallback) {
 }
 
 NAN_METHOD(Hook) {
-  NanScope();
   NanAssignPersistent(callback, args[0].As<v8::Function>());
   NanAddGCPrologueCallback(gcPrologueCallback);
   NanAddGCEpilogueCallback(gcEpilogueCallback);

--- a/test/cpp/isolatedata.cpp
+++ b/test/cpp/isolatedata.cpp
@@ -13,8 +13,6 @@ struct Dummy {
 };
 
 NAN_METHOD(SetAndGet) {
-  NanScope();
-
   Dummy *d0 = new Dummy;
   Dummy *d1 = NULL;
 

--- a/test/cpp/makecallback.cpp
+++ b/test/cpp/makecallback.cpp
@@ -30,8 +30,6 @@ MyObject::~MyObject() {
 }
 
 void MyObject::Init(v8::Handle<v8::Object> exports) {
-    NanScope();
-
     // Prepare constructor template
     v8::Local<v8::FunctionTemplate> tpl = NanNew<v8::FunctionTemplate>(New);
     tpl->SetClassName(NanNew<v8::String>("MyObject"));
@@ -44,8 +42,6 @@ void MyObject::Init(v8::Handle<v8::Object> exports) {
 }
 
 NAN_METHOD(MyObject::New) {
-    NanScope();
-
     if (args.IsConstructCall()) {
         MyObject* obj = new MyObject();
         obj->Wrap(args.This());
@@ -58,7 +54,6 @@ NAN_METHOD(MyObject::New) {
 }
 
 NAN_METHOD(MyObject::CallEmit) {
-    NanScope();
     v8::Handle<v8::Value> argv[1] = {
         NanNew("event"), // event name
     };

--- a/test/cpp/morenews.cpp
+++ b/test/cpp/morenews.cpp
@@ -9,34 +9,28 @@
 #include <nan.h>
 
 NAN_METHOD(NewNumber) {
-  NanScope();
   NanReturnValue(NanNew(0.5));
 }
 
 NAN_METHOD(NewNegativeInteger) {
-  NanScope();
   NanReturnValue(NanNew(-1));
 }
 
 NAN_METHOD(NewPositiveInteger) {
-  NanScope();
   NanReturnValue(NanNew(1));
 }
 
 NAN_METHOD(NewUtf8String) {
-  NanScope();
   const char s[] = "strïng";
   NanReturnValue(NanNew(s));
 }
 
 NAN_METHOD(NewLatin1String) {
-  NanScope();
   const uint8_t s[] = "str\xefng";
   NanReturnValue(NanNew(s));
 }
 
 NAN_METHOD(NewUcs2String) {
-  NanScope();
   uint16_t s[] = {'s', 't', 'r', 0xef, 'n', 'g', '\0'};
   NanReturnValue(NanNew(s));
 }
@@ -60,13 +54,11 @@ class ExtAsciiString : public NanExternalOneByteStringResource {
 };
 
 NAN_METHOD(NewExternalStringResource) {
-  NanScope();
   v8::Local<v8::String> ext = NanNew(new ExtString());
   NanReturnValue(ext);
 }
 
 NAN_METHOD(NewExternalAsciiStringResource) {
-  NanScope();
   v8::Local<v8::String> ext = NanNew(new ExtAsciiString());
   NanReturnValue(ext);
 }

--- a/test/cpp/multifile2.cpp
+++ b/test/cpp/multifile2.cpp
@@ -9,7 +9,6 @@
 #include <nan.h>
 
 NAN_METHOD(ReturnString) {
-  NanScope();
   v8::Local<v8::String> s = NanNew<v8::String>(*NanUtf8String(args[0]));
   NanReturnValue(s);
 }

--- a/test/cpp/nancallback.cpp
+++ b/test/cpp/nancallback.cpp
@@ -8,25 +8,18 @@
 
 #include <nan.h>
 
-
 NAN_METHOD(GlobalContext) {
-  NanScope();
-
   NanCallback(args[0].As<v8::Function>()).Call(0, NULL);
   NanReturnUndefined();
 }
 
 NAN_METHOD(SpecificContext) {
-  NanScope();
-
   NanCallback cb(args[0].As<v8::Function>());
   cb.Call(NanGetCurrentContext()->Global(), 0, NULL);
   NanReturnUndefined();
 }
 
 NAN_METHOD(CompareCallbacks) {
-  NanScope();
-
   NanCallback cb1(args[0].As<v8::Function>());
   NanCallback cb2(args[1].As<v8::Function>());
   NanCallback cb3(args[2].As<v8::Function>());

--- a/test/cpp/nannew.cpp
+++ b/test/cpp/nannew.cpp
@@ -52,7 +52,6 @@ stringMatches(Local<Value> value, const char * match) {
 #define _(e) NAN_TEST_EXPRESSION(e)
 
 NAN_METHOD(testArray) {
-  NanScope();
   NanTap t(args[0]);
 
   t.plan(3);
@@ -65,7 +64,6 @@ NAN_METHOD(testArray) {
 }
 
 NAN_METHOD(testBoolean) {
-  NanScope();
   NanTap t(args[0]);
 
   t.plan(6);
@@ -87,7 +85,6 @@ NAN_METHOD(testBoolean) {
 # define V(x) x->ValueOf()
 #endif
 NAN_METHOD(testBooleanObject) {
-  NanScope();
   NanTap t(args[0]);
 
   t.plan(3);
@@ -101,7 +98,6 @@ NAN_METHOD(testBooleanObject) {
 #undef V
 
 NAN_METHOD(testContext) {
-  NanScope();
   NanTap t(args[0]);
 
   t.plan(5);
@@ -121,7 +117,6 @@ NAN_METHOD(testContext) {
 }
 
 NAN_METHOD(testDate) {
-  NanScope();
   NanTap t(args[0]);
 
   t.plan(1);
@@ -134,7 +129,6 @@ NAN_METHOD(testDate) {
 int ttt = 23;
 
 NAN_METHOD(testExternal) {
-  NanScope();
   NanTap t(args[0]);
 
   t.plan(2);
@@ -146,7 +140,6 @@ NAN_METHOD(testExternal) {
 }
 
 NAN_METHOD(testFunction) {
-  NanScope();
   NanTap t(args[0]);
   t.plan(2);
 
@@ -158,7 +151,6 @@ NAN_METHOD(testFunction) {
 }
 
 NAN_METHOD(testFunctionTemplate) {
-  NanScope();
   NanTap t(args[0]);
 
   t.plan(4);
@@ -179,7 +171,6 @@ NAN_METHOD(testFunctionTemplate) {
 const double epsilon = 1e-9;
 
 NAN_METHOD(testNumber) {
-  NanScope();
   NanTap t(args[0]);
 
   t.plan(17);
@@ -214,7 +205,6 @@ NAN_METHOD(testNumber) {
 }
 
 NAN_METHOD(testNumberObject) {
-  NanScope();
   NanTap t(args[0]);
 
   t.plan(2);
@@ -226,7 +216,6 @@ NAN_METHOD(testNumberObject) {
 }
 
 NAN_METHOD(testObject) {
-  NanScope();
   NanTap t(args[0]);
 
   t.plan(1);
@@ -237,7 +226,6 @@ NAN_METHOD(testObject) {
 }
 
 NAN_METHOD(testObjectTemplate) {
-  NanScope();
   NanTap t(args[0]);
 
   t.plan(1);
@@ -248,7 +236,6 @@ NAN_METHOD(testObjectTemplate) {
 }
 
 NAN_METHOD(testScript) {
-  NanScope();
   NanTap t(args[0]);
 
   t.plan(6);
@@ -272,7 +259,6 @@ NAN_METHOD(testScript) {
 }
 
 NAN_METHOD(testSignature) {
-  NanScope();
   NanTap t(args[0]);
 
   t.plan(3);
@@ -289,7 +275,6 @@ NAN_METHOD(testSignature) {
 }
 
 NAN_METHOD(testString) {
-  NanScope();
   NanTap t(args[0]);
 
   t.plan(14);
@@ -328,7 +313,6 @@ NAN_METHOD(testString) {
 # define V(x) x->ValueOf()
 #endif
 NAN_METHOD(testStringObject) {
-  NanScope();
   NanTap t(args[0]);
 
   t.plan(2);
@@ -345,7 +329,6 @@ NAN_METHOD(testStringObject) {
 
 template <typename T> Handle<T> asHandle(Local<T> l) { return l; }
 NAN_METHOD(testHandles) {
-  NanScope();
   NanTap t(args[0]);
 
   t.plan(2);
@@ -357,7 +340,6 @@ NAN_METHOD(testHandles) {
 }
 
 NAN_METHOD(testPersistents) {
-  NanScope();
   NanTap t(args[0]);
 
   t.plan(1);
@@ -377,7 +359,6 @@ NAN_METHOD(testPersistents) {
 
 // See https://github.com/iojs/nan/issues/212
 NAN_METHOD(testRegression212) {
-  NanScope();
   NanTap t(args[0]);
 
   t.plan(1);
@@ -407,7 +388,6 @@ NAN_METHOD(overloaded) {
 }
 
 NAN_METHOD(testRegression242) {
-  NanScope();
   NanTap t(args[0]);
 
   // These lines must *compile*. Not much to test at runtime.
@@ -429,37 +409,30 @@ NAN_METHOD(testRegression242) {
 //==============================================================================
 
 NAN_METHOD(newIntegerWithValue) {
-  NanScope();
   return_NanValue(NanNew<Integer>(args[0]->Int32Value()));
 }
 
 NAN_METHOD(newNumberWithValue) {
-  NanScope();
   return_NanValue(NanNew<Number>(args[0]->NumberValue()));
 }
 
 NAN_METHOD(newUint32WithValue) {
-  NanScope();
   return_NanValue(NanNew<Uint32>(args[0]->Uint32Value()));
 }
 
 NAN_METHOD(newStringFromChars) {
-  NanScope();
   return_NanValue(NanNew<String>("hello?"));
 }
 
 NAN_METHOD(newStringFromCharsWithLength) {
-  NanScope();
   return_NanValue(NanNew<String>("hello?", 4));
 }
 
 NAN_METHOD(newStringFromStdString) {
-  NanScope();
   return_NanValue(NanNew<String>(std::string("hello!")));
 }
 
 NAN_METHOD(newExternal) {
-  NanScope();
   return_NanValue(NanNew<External>(&ttt));
 }
 

--- a/test/cpp/news.cpp
+++ b/test/cpp/news.cpp
@@ -19,98 +19,80 @@
 static int magic = 1337;
 
 NAN_METHOD(NewNumber) {
-  NanScope();
   NanReturnValue(NanNew<v8::Number>(0.5));
 }
 
 NAN_METHOD(NewNegativeInteger) {
-  NanScope();
   NanReturnValue(NanNew<v8::Integer>(-1));
 }
 
 NAN_METHOD(NewPositiveInteger) {
-  NanScope();
   NanReturnValue(NanNew<v8::Integer>(1));
 }
 
 NAN_METHOD(NewUnsignedInteger) {
-  NanScope();
   NanReturnValue(NanNew<v8::Integer>(0xFFFFFFFFu));
 }
 
 NAN_METHOD(NewInt32FromPositive) {
-  NanScope();
   NanReturnValue(NanNew<v8::Int32>(0xFFFFFFFF));
 }
 
 NAN_METHOD(NewInt32FromNegative) {
-  NanScope();
   NanReturnValue(NanNew<v8::Int32>(-1));
 }
 
 NAN_METHOD(NewUint32FromPositive) {
-  NanScope();
   NanReturnValue(NanNew<v8::Uint32>(0xFFFFFFFF));
 }
 
 NAN_METHOD(NewUint32FromNegative) {
-  NanScope();
   NanReturnValue(NanNew<v8::Uint32>(-1));
 }
 
 NAN_METHOD(NewUtf8String) {
-  NanScope();
   const char s[] = "strïng";
   NanReturnValue(NanNew<v8::String>(s));
 }
 
 NAN_METHOD(NewLatin1String) {
-  NanScope();
   const uint8_t s[] = "str\xefng";
   NanReturnValue(NanNew<v8::String>(s));
 }
 
 NAN_METHOD(NewUcs2String) {
-  NanScope();
   const uint16_t s[] = {'s', 't', 'r', 0xef, 'n', 'g', '\0'};
   NanReturnValue(NanNew(s));
 }
 
 NAN_METHOD(NewStdString) {
-  NanScope();
   const std::string s = "strïng";
   NanReturnValue(NanNew<v8::String>(s));
 }
 
 NAN_METHOD(NewRegExp) {
-  NanScope();
   NanReturnValue(NanNew<v8::RegExp>(NanNew("foo"), v8::RegExp::kNone));
 }
 
 NAN_METHOD(NewStringObject) {
-  NanScope();
   NanReturnValue(NanNew<v8::StringObject>(NanNew<v8::String>("foo")));
 }
 
 NAN_METHOD(NewNumberObject) {
-  NanScope();
   NanReturnValue(NanNew<v8::NumberObject>(0.5));
 }
 
 NAN_METHOD(NewBooleanObject) {
-  NanScope();
   NanReturnValue(NanNew<v8::BooleanObject>(true));
 }
 
 NAN_METHOD(NewExternal) {
-  NanScope();
   v8::Local<v8::External> ext = NanNew<v8::External>(&magic);
   assert(*static_cast<int *>(ext->Value()) == 1337);
   NanReturnValue(NanNew<v8::String>("passed"));
 }
 
 NAN_METHOD(NewSignature) {
-  NanScope();
   v8::Local<v8::FunctionTemplate> tmpl =
       NanNew<v8::FunctionTemplate>(NewSignature);
   v8::Local<v8::Signature> sig = NanNew<v8::Signature>(tmpl);
@@ -120,13 +102,11 @@ NAN_METHOD(NewSignature) {
 }
 
 NAN_METHOD(NewScript) {
-  NanScope();
   v8::Local<NanUnboundScript> script = NanNew<NanUnboundScript>(NanNew("2+4"));
   NanReturnValue(NanRunScript(script)->ToInt32());
 }
 
 NAN_METHOD(NewScript2) {
-  NanScope();
   v8::ScriptOrigin origin(NanNew<v8::String>("x"));
   v8::Local<NanUnboundScript> script =
       NanNew<NanUnboundScript>(NanNew("2+4"), origin);
@@ -134,37 +114,30 @@ NAN_METHOD(NewScript2) {
 }
 
 NAN_METHOD(CompileScript) {
-  NanScope();
   v8::Local<NanBoundScript> script = NanCompileScript(NanNew("2+4"));
   NanReturnValue(NanRunScript(script)->ToInt32());
 }
 
 NAN_METHOD(CompileScript2) {
-  NanScope();
   v8::ScriptOrigin origin(NanNew<v8::String>("x"));
   v8::Local<NanBoundScript> script = NanCompileScript(NanNew("2+4"), origin);
   NanReturnValue(NanRunScript(script)->ToInt32());
 }
 
 NAN_METHOD(NewDate) {
-  NanScope();
   NanReturnValue(NanNew<v8::Date>(1337));
 }
 
 NAN_METHOD(NewArray) {
-  NanScope();
   NanReturnValue(NanNew<v8::Array>());
 }
 
 NAN_METHOD(NewBoolean) {
-  NanScope();
   NanReturnValue(NanNew<v8::Boolean>(true));
 }
 
 // #212
 NAN_METHOD(NewBoolean2) {
-  NanScope();
-
 #if defined(_MSC_VER)
 # pragma warning( push )
 # pragma warning( disable : 4800 )

--- a/test/cpp/objectwraphandle.cpp
+++ b/test/cpp/objectwraphandle.cpp
@@ -11,7 +11,6 @@
 class MyObject : public node::ObjectWrap {
  public:
   static void Init(v8::Handle<v8::Object> exports) {
-    NanScope();
     v8::Local<v8::FunctionTemplate> tpl = NanNew<v8::FunctionTemplate>(New);
     tpl->SetClassName(NanNew("MyObject"));
     tpl->InstanceTemplate()->SetInternalFieldCount(1);
@@ -27,8 +26,6 @@ class MyObject : public node::ObjectWrap {
   ~MyObject() {}
 
   static NAN_METHOD(New) {
-    NanScope();
-
     if (args.IsConstructCall()) {
       double value = args[0]->IsUndefined() ? 0 : args[0]->NumberValue();
       MyObject *obj = new MyObject(value);
@@ -43,7 +40,6 @@ class MyObject : public node::ObjectWrap {
   }
 
   static NAN_METHOD(GetHandle) {
-    NanScope();
     MyObject* obj = node::ObjectWrap::Unwrap<MyObject>(args.This());
     NanReturnValue(NanObjectWrapHandle(obj));
   }

--- a/test/cpp/objectwraphandle.cpp
+++ b/test/cpp/objectwraphandle.cpp
@@ -8,7 +8,7 @@
 
 #include <nan.h>
 
-class MyObject : public node::ObjectWrap {
+class MyObject : public NanObjectWrap {
  public:
   static void Init(v8::Handle<v8::Object> exports) {
     v8::Local<v8::FunctionTemplate> tpl = NanNew<v8::FunctionTemplate>(New);
@@ -40,8 +40,8 @@ class MyObject : public node::ObjectWrap {
   }
 
   static NAN_METHOD(GetHandle) {
-    MyObject* obj = node::ObjectWrap::Unwrap<MyObject>(args.This());
-    NanReturnValue(NanObjectWrapHandle(obj));
+    MyObject* obj = NanObjectWrap::Unwrap<MyObject>(args.This());
+    NanReturnValue(obj->handle());
   }
 
   static v8::Persistent<v8::Function> constructor;

--- a/test/cpp/persistent.cpp
+++ b/test/cpp/persistent.cpp
@@ -12,48 +12,34 @@
 static v8::Persistent<v8::String> persistentTest1;
 
 NAN_METHOD(Save1) {
-  NanScope();
-
   NanAssignPersistent(persistentTest1, args[0].As<v8::String>());
-
   NanReturnUndefined();
 }
 
 NAN_METHOD(Get1) {
-  NanScope();
-
   NanReturnValue(NanNew(persistentTest1));
 }
 
 NAN_METHOD(Dispose1) {
-  NanScope();
-
   NanDisposePersistent(persistentTest1);
-
   NanReturnUndefined();
 }
 
 NAN_METHOD(ToPersistentAndBackAgain) {
-  NanScope();
-
   v8::Persistent<v8::Object> persistent;
   NanAssignPersistent(persistent, args[0].As<v8::Object>());
   v8::Local<v8::Object> object = NanNew(persistent);
   NanDisposePersistent(persistent);
   memset(&persistent, -1, sizeof(persistent));  // Clobber it good.
-
   NanReturnValue(object);
 }
 
 NAN_METHOD(PersistentToPersistent) {
-  NanScope();
-
   v8::Persistent<v8::String> persistent;
   NanAssignPersistent(persistent, args[0].As<v8::String>());
   NanAssignPersistent(persistentTest1, persistent);
   NanDisposePersistent(persistent);
   NanDisposePersistent(persistentTest1);
-
   NanReturnUndefined();
 }
 

--- a/test/cpp/returnemptystring.cpp
+++ b/test/cpp/returnemptystring.cpp
@@ -9,7 +9,6 @@
 #include <nan.h>
 
 NAN_METHOD(ReturnEmptyString) {
-  NanScope();
   NanReturnEmptyString();
 }
 

--- a/test/cpp/returnnull.cpp
+++ b/test/cpp/returnnull.cpp
@@ -9,7 +9,6 @@
 #include <nan.h>
 
 NAN_METHOD(ReturnNull) {
-  NanScope();
   NanReturnNull();
 }
 

--- a/test/cpp/returnundefined.cpp
+++ b/test/cpp/returnundefined.cpp
@@ -9,7 +9,6 @@
 #include <nan.h>
 
 NAN_METHOD(ReturnUndefined) {
-  NanScope();
   NanReturnUndefined();
 }
 

--- a/test/cpp/returnvalue.cpp
+++ b/test/cpp/returnvalue.cpp
@@ -11,7 +11,6 @@
 v8::Persistent<v8::Boolean> persistent;
 
 NAN_METHOD(ReturnValue) {
-  NanScope();
   if (args.Length() == 1) {
     NanReturnValue(args[0]);
   } else {
@@ -20,17 +19,14 @@ NAN_METHOD(ReturnValue) {
 }
 
 NAN_METHOD(ReturnPrimitive) {
-  NanScope();
   NanReturnValue(true);
 }
 
 NAN_METHOD(ReturnString) {
-  NanScope();
   NanReturnValue("yes, it works");
 }
 
 NAN_METHOD(ReturnPersistent) {
-  NanScope();
   NanReturnValue(persistent);
 }
 

--- a/test/cpp/settemplate.cpp
+++ b/test/cpp/settemplate.cpp
@@ -29,8 +29,6 @@ MyObject::~MyObject() {
 }
 
 void MyObject::Init(v8::Handle<v8::Object> exports) {
-	NanScope();
-
 	// Prepare constructor template
 	v8::Local<v8::FunctionTemplate> tpl = NanNew<v8::FunctionTemplate>(New);
 	tpl->SetClassName(NanNew<v8::String>("MyObject"));
@@ -51,8 +49,6 @@ void MyObject::Init(v8::Handle<v8::Object> exports) {
 }
 
 NAN_METHOD(MyObject::New) {
-	NanScope();
-
 	if (args.IsConstructCall()) {
 		MyObject* obj = new MyObject();
 		obj->Wrap(args.This());

--- a/test/cpp/settergetter.cpp
+++ b/test/cpp/settergetter.cpp
@@ -60,12 +60,12 @@ void SetterGetter::Init(v8::Handle<v8::Object> target) {
 }
 
 v8::Handle<v8::Value> SetterGetter::NewInstance () {
-  NanEscapableScope();
+  NanEscapableScope scope;
   v8::Local<v8::FunctionTemplate> constructorHandle =
       NanNew(settergetter_constructor);
   v8::Local<v8::Object> instance =
     constructorHandle->GetFunction()->NewInstance(0, NULL);
-  return NanEscapeScope(instance);
+  return scope.Escape(instance);
 }
 
 NAN_METHOD(SetterGetter::New) {

--- a/test/cpp/settergetter.cpp
+++ b/test/cpp/settergetter.cpp
@@ -29,7 +29,6 @@ class SetterGetter : public node::ObjectWrap {
 static v8::Persistent<v8::FunctionTemplate> settergetter_constructor;
 
 NAN_METHOD(CreateNew) {
-  NanScope();
   NanReturnValue(SetterGetter::NewInstance());
 }
 
@@ -61,16 +60,15 @@ void SetterGetter::Init(v8::Handle<v8::Object> target) {
 }
 
 v8::Handle<v8::Value> SetterGetter::NewInstance () {
+  NanEscapableScope();
   v8::Local<v8::FunctionTemplate> constructorHandle =
       NanNew(settergetter_constructor);
   v8::Local<v8::Object> instance =
     constructorHandle->GetFunction()->NewInstance(0, NULL);
-  return instance;
+  return NanEscapeScope(instance);
 }
 
 NAN_METHOD(SetterGetter::New) {
-  NanScope();
-
   SetterGetter* settergetter = new SetterGetter();
   assert(strlen(settergetter->log) < sizeof (settergetter->log));
   strncat(
@@ -83,8 +81,6 @@ NAN_METHOD(SetterGetter::New) {
 }
 
 NAN_GETTER(SetterGetter::GetProp1) {
-  NanScope();
-
   SetterGetter* settergetter =
     node::ObjectWrap::Unwrap<SetterGetter>(args.This());
   assert(strlen(settergetter->log) < sizeof (settergetter->log));
@@ -107,8 +103,6 @@ NAN_GETTER(SetterGetter::GetProp1) {
 }
 
 NAN_GETTER(SetterGetter::GetProp2) {
-  NanScope();
-
   SetterGetter* settergetter =
     node::ObjectWrap::Unwrap<SetterGetter>(args.This());
   assert(strlen(settergetter->log) < sizeof (settergetter->log));
@@ -131,8 +125,6 @@ NAN_GETTER(SetterGetter::GetProp2) {
 }
 
 NAN_SETTER(SetterGetter::SetProp2) {
-  NanScope();
-
   SetterGetter* settergetter =
       node::ObjectWrap::Unwrap<SetterGetter>(args.This());
   strncpy(
@@ -158,8 +150,6 @@ NAN_SETTER(SetterGetter::SetProp2) {
 }
 
 NAN_METHOD(SetterGetter::Log) {
-  NanScope();
-
   SetterGetter* settergetter =
     node::ObjectWrap::Unwrap<SetterGetter>(args.This());
 

--- a/test/cpp/strings.cpp
+++ b/test/cpp/strings.cpp
@@ -9,22 +9,18 @@
 #include <nan.h>
 
 NAN_METHOD(ReturnAsciiString) {
-  NanScope();
   NanReturnValue(NanNew(*NanAsciiString(args[0])));
 }
 
 NAN_METHOD(ReturnUtf8String) {
-  NanScope();
   NanReturnValue(NanNew(*NanUtf8String(args[0])));
 }
 
 NAN_METHOD(ReturnUcs2String) {
-  NanScope();
   NanReturnValue(NanNew(*NanUcs2String(args[0])));
 }
 
 NAN_METHOD(HeapString) {
-  NanScope();
   NanUcs2String *s = new NanUcs2String(args[0]);
   v8::Local<v8::String> res = NanNew(**s);
   delete s;
@@ -32,12 +28,10 @@ NAN_METHOD(HeapString) {
 }
 
 NAN_METHOD(EncodeHex) {
-  NanScope();
   NanReturnValue(NanEncode("hello", 5, Nan::HEX));
 }
 
 NAN_METHOD(EncodeUCS2) {
-  NanScope();
   NanReturnValue(NanEncode("h\0e\0l\0l\0o\0", 10, Nan::UCS2));
 }
 
@@ -49,8 +43,6 @@ v8::Persistent<v8::FunctionTemplate> encodeHex_persistent;
 v8::Persistent<v8::FunctionTemplate> encodeUCS2_persistent;
 
 void Init (v8::Handle<v8::Object> target) {
-  NanScope();
-
   v8::Local<v8::FunctionTemplate> returnAsciiString =
     NanNew<v8::FunctionTemplate>(ReturnAsciiString);
 

--- a/test/cpp/threadlocal.cpp
+++ b/test/cpp/threadlocal.cpp
@@ -29,7 +29,7 @@ public:
     ok(_(NULL == nauv_key_get(&tls_key)));
   }
   void WorkComplete() {
-    NanScope();
+    NanScope scope;
     for (unsigned j = 0; j < i; ++j)
       t->ok(res[j].ok, res[j].msg);
     nauv_key_delete(&tls_key);

--- a/test/cpp/threadlocal.cpp
+++ b/test/cpp/threadlocal.cpp
@@ -15,7 +15,6 @@
 class TlsTest : public NanAsyncWorker {
 public:
   TlsTest(NanTap *t) : NanAsyncWorker(NULL), t(t), i(0) {
-    NanScope();
     t->plan(7);
     t->ok(_(0 == nauv_key_create(&tls_key)));
     t->ok(_(NULL == nauv_key_get(&tls_key)));
@@ -52,7 +51,6 @@ private:
 };
 
 NAN_METHOD(thread_local_storage) {
-  NanScope();
   NanTap *t = new NanTap(args[0]);
   NanAsyncQueueWorker(new TlsTest(t));
   return_NanUndefined();

--- a/test/cpp/weak.cpp
+++ b/test/cpp/weak.cpp
@@ -28,7 +28,6 @@ v8::Handle<v8::String> wrap(v8::Local<v8::Function> func) {
 }
 
 NAN_METHOD(Hustle) {
-  NanScope();
   NanReturnValue(wrap(args[0].As<v8::Function>()));
 }
 

--- a/test/cpp/weak.cpp
+++ b/test/cpp/weak.cpp
@@ -8,7 +8,8 @@
 
 #include <nan.h>
 
-NAN_WEAK_CALLBACK(weakCallback) {
+void weakCallback(
+NanWeakCallbackData<v8::Function, int> & data) {  // NOLINT(runtime/references)
   int *parameter = data.GetParameter();
   NanMakeCallback(NanGetCurrentContext()->Global(), data.GetValue(), 0, NULL);
   if ((*parameter)++ == 0) {
@@ -19,10 +20,11 @@ NAN_WEAK_CALLBACK(weakCallback) {
 }
 
 v8::Handle<v8::String> wrap(v8::Local<v8::Function> func) {
+  NanEscapableScope();
   v8::Local<v8::String> lstring = NanNew<v8::String>("result");
   int *parameter = new int(0);
-  NanMakeWeakPersistent(func, parameter, &weakCallback);
-  return lstring;
+  NanMakeWeakPersistent(func, parameter, weakCallback);
+  return NanEscapeScope(lstring);
 }
 
 NAN_METHOD(Hustle) {

--- a/test/cpp/weak.cpp
+++ b/test/cpp/weak.cpp
@@ -20,11 +20,11 @@ NanWeakCallbackData<v8::Function, int> & data) {  // NOLINT(runtime/references)
 }
 
 v8::Handle<v8::String> wrap(v8::Local<v8::Function> func) {
-  NanEscapableScope();
+  NanEscapableScope scope;
   v8::Local<v8::String> lstring = NanNew<v8::String>("result");
   int *parameter = new int(0);
   NanMakeWeakPersistent(func, parameter, weakCallback);
-  return NanEscapeScope(lstring);
+  return scope.Escape(lstring);
 }
 
 NAN_METHOD(Hustle) {

--- a/test/js/bufferworkerpersistent-test.js
+++ b/test/js/bufferworkerpersistent-test.js
@@ -13,19 +13,15 @@ const test     = require('tap').test
 
 test('bufferworkerpersistent', function (t) {
   var worker = bindings.a
-    , called = false
+    , called = 0
     , buf    = crypto.randomBytes(256)
     , bufHex = buf.toString('hex')
 
+  t.plan(7);
+
   t.type(worker, 'function')
 
-  setTimeout(function () {
-    t.ok(called, 'callback fired')
-    t.end()
-  }, 500)
-
   worker(200, buf, function (_buf) {
-    called = true
     t.ok(Buffer.isBuffer(_buf), 'is buffer arg')
     t.equal(_buf.toString('hex'), bufHex)
   })


### PR DESCRIPTION
Replaced a bunch of macros with classes. The only ones left are `NanReturnValue` et al. Can't figure out a good way of removing them. I considered wrapping all exported functions similarly to the weak callback and adding a `NanExport` function, but that leaves the problem of resolving the right function when doing new `FunctionTemplate` or `Function`.