### PR TITLE
Fix gc text

### DIFF
--- a/test/js/gc-test.js
+++ b/test/js/gc-test.js
@@ -14,10 +14,9 @@ test('gc', function (t) {
   t.plan(3);
 
   t.type(bindings.hook, 'function');
+  t.type(bindings.check, 'function');
 
-  bindings.hook(function (from) {
-    t.ok(from == 'prologue' || from == 'epilogue');
-  });
-
+  bindings.hook();
   gc();
+  t.ok(bindings.check());
 });


### PR DESCRIPTION
Debug builds would assert that it is not allowed to allocate v8 handles in gc callbacks.